### PR TITLE
fix: ミドルウェアのEdge Runtime対応

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,14 @@
+import type { NextAuthConfig } from "next-auth";
+
+// Edge Runtime対応のミドルウェア専用設定（Prismaを使わない）
+export const authConfig: NextAuthConfig = {
+  pages: {
+    signIn: "/login",
+  },
+  providers: [],
+  callbacks: {
+    authorized({ auth }) {
+      return !!auth?.user;
+    },
+  },
+};

--- a/auth.ts
+++ b/auth.ts
@@ -3,13 +3,12 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
+import { authConfig } from "./auth.config";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  ...authConfig,
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
-  pages: {
-    signIn: "/login",
-  },
   providers: [
     Credentials({
       credentials: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,7 @@
-export { auth as middleware } from "@/auth";
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export const { auth: middleware } = NextAuth(authConfig);
 
 export const config = {
   matcher: ["/((?!api|_next/static|_next/image|favicon.ico|login|signup).*)"],


### PR DESCRIPTION
## Summary
- `auth.config.ts` を新規作成（Prismaなし・Edge Runtime対応）
- `middleware.ts` を `auth.config.ts` ベースに変更
- `auth.ts` は `auth.config.ts` を継承しつつPrismaAdapterを追加

## 原因
Next.jsのミドルウェアはEdge Runtimeで動作するため、`node:path` などNode.js組み込みモジュールを使うPrismaクライアントが読み込めなかった。