### PR TITLE
feat: グループ・メンバー・依頼のスキーマを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: group_point
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/prisma/migrations/20260321000000_add_groups_members_quests/migration.sql
+++ b/prisma/migrations/20260321000000_add_groups_members_quests/migration.sql
@@ -1,0 +1,67 @@
+-- CreateEnum
+CREATE TYPE "GroupRole" AS ENUM ('LEADER', 'MEMBER');
+
+-- CreateEnum
+CREATE TYPE "QuestType" AS ENUM ('GOVERNMENT', 'MEMBER');
+
+-- CreateEnum
+CREATE TYPE "QuestStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "totalIssuedPoints" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroupMember" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "role" "GroupRole" NOT NULL DEFAULT 'MEMBER',
+    "memberPoints" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GroupMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Quest" (
+    "id" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "creatorId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "pointReward" INTEGER NOT NULL,
+    "questType" "QuestType" NOT NULL,
+    "status" "QuestStatus" NOT NULL DEFAULT 'OPEN',
+    "completerId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Quest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GroupMember_userId_groupId_key" ON "GroupMember"("userId", "groupId");
+
+-- AddForeignKey
+ALTER TABLE "GroupMember" ADD CONSTRAINT "GroupMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMember" ADD CONSTRAINT "GroupMember_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Quest" ADD CONSTRAINT "Quest_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Quest" ADD CONSTRAINT "Quest_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "GroupMember"("id") ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Quest" ADD CONSTRAINT "Quest_completerId_fkey" FOREIGN KEY ("completerId") REFERENCES "GroupMember"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,16 +11,90 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(cuid())
+  id            String        @id @default(cuid())
   name          String?
-  email         String    @unique
+  email         String        @unique
   emailVerified DateTime?
   password      String?
   image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
   accounts      Account[]
   sessions      Session[]
+  groupMembers  GroupMember[]
+}
+
+// ─── グループ ───────────────────────────────────────────────
+
+/// グループ（コミュニティ）。リーダー（政府）が政府ポイントを発行・依頼を作成できる。
+model Group {
+  id                String        @id @default(cuid())
+  name              String
+  /// 政府がこれまでに発行した累計ポイント数
+  totalIssuedPoints Int           @default(0)
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  members           GroupMember[]
+  quests            Quest[]
+}
+
+/// グループとユーザーの中間テーブル。ロールとメンバーポイント残高を保持。
+model GroupMember {
+  id           String      @id @default(cuid())
+  userId       String
+  groupId      String
+  role         GroupRole   @default(MEMBER)
+  /// メンバーが保有するポイント残高（政府依頼達成・メンバー依頼受取で増減）
+  memberPoints Int         @default(0)
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+  user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group        Group       @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  createdQuests  Quest[]   @relation("QuestCreator")
+  completedQuests Quest[]  @relation("QuestCompleter")
+
+  @@unique([userId, groupId])
+}
+
+enum GroupRole {
+  LEADER  // 政府（グループ長）
+  MEMBER  // 一般メンバー
+}
+
+// ─── 依頼（クエスト）────────────────────────────────────────
+
+/// 依頼。政府発行とメンバー発行の2種類がある。
+model Quest {
+  id          String       @id @default(cuid())
+  groupId     String
+  /// 依頼作成者（GroupMember.id）
+  creatorId   String
+  title       String
+  description String?
+  /// 報酬ポイント数
+  pointReward Int
+  /// GOVERNMENT: 政府発行（政府ポイントを新規付与）/ MEMBER: メンバー発行（作成者のポイントを報酬として使用）
+  questType   QuestType
+  status      QuestStatus  @default(OPEN)
+  /// 依頼完了者（GroupMember.id）
+  completerId String?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  group       Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  creator     GroupMember  @relation("QuestCreator", fields: [creatorId], references: [id])
+  completer   GroupMember? @relation("QuestCompleter", fields: [completerId], references: [id])
+}
+
+enum QuestType {
+  GOVERNMENT  // 政府発行の依頼：達成すると政府ポイントが付与される
+  MEMBER      // メンバー発行の依頼：作成者のメンバーポイントが報酬となる
+}
+
+enum QuestStatus {
+  OPEN        // 受付中
+  IN_PROGRESS // 進行中
+  COMPLETED   // 完了
+  CANCELLED   // キャンセル
 }
 
 model Account {


### PR DESCRIPTION
## 概要

ポイントシステム・グループ・依頼機能のDBスキーマを追加します。

## 追加内容

### モデル
- **Group**: グループ（政府ポイント累計発行数を管理）
- **GroupMember**: メンバーのロール（LEADER/MEMBER）とポイント残高
- **Quest**: 政府発行（GOVERNMENT）とメンバー発行（MEMBER）の依頼

### ポイント設計
- 政府ポイント（`Group.totalIssuedPoints`）とメンバーポイント（`GroupMember.memberPoints`）を明確に分離
- グループ全体の流通ポイントはメンバー全員の `memberPoints` 合計で算出

### その他
- `docker-compose.yml`: PostgreSQL開発用コンテナ設定を追加