### PR TITLE
feat: グループ招待機能を追加

### DIFF
--- a/app/InvitationList.tsx
+++ b/app/InvitationList.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Invitation = {
+  id: string;
+  role: "LEADER" | "MEMBER";
+  group: { id: string; name: string };
+  inviter: {
+    user: { id: string; name: string | null; email: string };
+  };
+};
+
+export default function InvitationList() {
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [processing, setProcessing] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/invitations")
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) setInvitations(data);
+      });
+  }, []);
+
+  async function respond(id: string, action: "accept" | "decline") {
+    setProcessing(id);
+    try {
+      await fetch(`/api/invitations/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      setInvitations((prev) => prev.filter((inv) => inv.id !== id));
+    } finally {
+      setProcessing(null);
+    }
+  }
+
+  if (invitations.length === 0) return null;
+
+  return (
+    <section>
+      <h3 className="font-semibold text-gray-700 mb-3">
+        招待が届いています
+        <span className="ml-2 text-blue-600 font-bold">{invitations.length}</span>
+      </h3>
+      <ul className="space-y-3">
+        {invitations.map((inv) => (
+          <li
+            key={inv.id}
+            className="bg-white border border-blue-200 rounded-xl px-6 py-4 flex items-center justify-between gap-4"
+          >
+            <div>
+              <p className="text-sm font-medium text-gray-800">
+                <span className="text-blue-600">{inv.group.name}</span> から招待が届いています
+              </p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                招待者: {inv.inviter.user.name ?? inv.inviter.user.email} ／
+                ロール: {inv.role === "LEADER" ? "政府関係者（LEADER）" : "一般メンバー"}
+              </p>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <button
+                onClick={() => respond(inv.id, "accept")}
+                disabled={processing === inv.id}
+                className="px-4 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+              >
+                承認
+              </button>
+              <button
+                onClick={() => respond(inv.id, "decline")}
+                disabled={processing === inv.id}
+                className="px-4 py-1.5 bg-gray-100 text-gray-600 text-sm rounded-lg hover:bg-gray-200 disabled:opacity-50 transition"
+              >
+                拒否
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/api/groups/[id]/invitations/route.ts
+++ b/app/api/groups/[id]/invitations/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// グループへの招待を送る（LEADERのみ）
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const { id: groupId } = await params;
+  const { email, role } = await req.json();
+
+  if (!email?.trim()) {
+    return NextResponse.json({ error: "メールアドレスは必須です" }, { status: 400 });
+  }
+  if (role !== "LEADER" && role !== "MEMBER") {
+    return NextResponse.json({ error: "roleはLEADERまたはMEMBERを指定してください" }, { status: 400 });
+  }
+
+  // 操作者がLEADERか確認
+  const inviterMember = await prisma.groupMember.findUnique({
+    where: { userId_groupId: { userId: session.user.id, groupId } },
+  });
+  if (!inviterMember || inviterMember.role !== "LEADER") {
+    return NextResponse.json({ error: "この操作はLEADERのみ実行できます" }, { status: 403 });
+  }
+
+  // 招待対象ユーザーを検索
+  const invitee = await prisma.user.findUnique({ where: { email: email.trim() } });
+  if (!invitee) {
+    return NextResponse.json({ error: "指定されたメールアドレスのユーザーが見つかりません" }, { status: 404 });
+  }
+
+  // 既にメンバーの場合はエラー
+  const alreadyMember = await prisma.groupMember.findUnique({
+    where: { userId_groupId: { userId: invitee.id, groupId } },
+  });
+  if (alreadyMember) {
+    return NextResponse.json({ error: "このユーザーはすでにグループのメンバーです" }, { status: 409 });
+  }
+
+  // 既存の招待があれば再送（ステータスをPENDINGに戻す）
+  const invitation = await prisma.invitation.upsert({
+    where: { groupId_inviteeId: { groupId, inviteeId: invitee.id } },
+    update: { status: "PENDING", role, inviterId: inviterMember.id },
+    create: {
+      groupId,
+      inviterId: inviterMember.id,
+      inviteeId: invitee.id,
+      role,
+    },
+    include: {
+      group: { select: { id: true, name: true } },
+      invitee: { select: { id: true, name: true, email: true } },
+    },
+  });
+
+  return NextResponse.json(invitation, { status: 201 });
+}

--- a/app/api/invitations/[id]/route.ts
+++ b/app/api/invitations/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// 招待を承認または拒否する
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { action } = await req.json(); // "accept" | "decline"
+
+  if (action !== "accept" && action !== "decline") {
+    return NextResponse.json({ error: "actionはacceptまたはdeclineを指定してください" }, { status: 400 });
+  }
+
+  const invitation = await prisma.invitation.findUnique({ where: { id } });
+  if (!invitation) {
+    return NextResponse.json({ error: "招待が見つかりません" }, { status: 404 });
+  }
+  if (invitation.inviteeId !== session.user.id) {
+    return NextResponse.json({ error: "この招待を操作する権限がありません" }, { status: 403 });
+  }
+  if (invitation.status !== "PENDING") {
+    return NextResponse.json({ error: "この招待はすでに回答済みです" }, { status: 409 });
+  }
+
+  if (action === "accept") {
+    // トランザクションでメンバー追加と招待ステータス更新を同時に行う
+    await prisma.$transaction([
+      prisma.groupMember.upsert({
+        where: { userId_groupId: { userId: session.user.id, groupId: invitation.groupId } },
+        update: { role: invitation.role },
+        create: { userId: session.user.id, groupId: invitation.groupId, role: invitation.role },
+      }),
+      prisma.invitation.update({
+        where: { id },
+        data: { status: "ACCEPTED" },
+      }),
+    ]);
+  } else {
+    await prisma.invitation.update({
+      where: { id },
+      data: { status: "DECLINED" },
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/invitations/route.ts
+++ b/app/api/invitations/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// 自分宛の招待一覧を取得
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const invitations = await prisma.invitation.findMany({
+    where: { inviteeId: session.user.id, status: "PENDING" },
+    include: {
+      group: { select: { id: true, name: true } },
+      inviter: {
+        include: { user: { select: { id: true, name: true, email: true } } },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(invitations);
+}

--- a/app/groups/[id]/page.tsx
+++ b/app/groups/[id]/page.tsx
@@ -22,7 +22,7 @@ export default function GroupDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [group, setGroup] = useState<Group | null>(null);
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<"LEADER" | "MEMBER">("LEADER");
+  const [role, setRole] = useState<"LEADER" | "MEMBER">("MEMBER");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
@@ -38,13 +38,13 @@ export default function GroupDetailPage() {
       });
   }, [id]);
 
-  async function handleAddMember(e: React.FormEvent) {
+  async function handleInvite(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setSuccess("");
     setSubmitting(true);
     try {
-      const res = await fetch(`/api/groups/${id}/members`, {
+      const res = await fetch(`/api/groups/${id}/invitations`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, role }),
@@ -54,22 +54,8 @@ export default function GroupDetailPage() {
         setError(data.error ?? "エラーが発生しました");
         return;
       }
-      setSuccess(
-        `${data.user.name ?? data.user.email} を ${role === "LEADER" ? "政府関係者（LEADER）" : "メンバー"} として登録しました`
-      );
+      setSuccess(`${data.invitee.name ?? data.invitee.email} に招待を送りました`);
       setEmail("");
-      // メンバー一覧を更新
-      setGroup((prev) => {
-        if (!prev) return prev;
-        const exists = prev.members.find((m) => m.id === data.id);
-        if (exists) {
-          return {
-            ...prev,
-            members: prev.members.map((m) => (m.id === data.id ? data : m)),
-          };
-        }
-        return { ...prev, members: [...prev.members, data] };
-      });
     } finally {
       setSubmitting(false);
     }
@@ -103,10 +89,11 @@ export default function GroupDetailPage() {
           </div>
         </section>
 
-        {/* 政府関係者登録フォーム */}
+        {/* 招待フォーム */}
         <section className="bg-white border border-gray-200 rounded-xl p-6">
-          <h3 className="font-semibold text-gray-800 mb-4">メンバーを登録</h3>
-          <form onSubmit={handleAddMember} className="space-y-3">
+          <h3 className="font-semibold text-gray-800 mb-1">メンバーを招待</h3>
+          <p className="text-xs text-gray-400 mb-4">招待されたユーザーがトップページで承認するとメンバーになります</p>
+          <form onSubmit={handleInvite} className="space-y-3">
             <div className="flex gap-3">
               <input
                 type="email"
@@ -121,8 +108,8 @@ export default function GroupDetailPage() {
                 onChange={(e) => setRole(e.target.value as "LEADER" | "MEMBER")}
                 className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
               >
-                <option value="LEADER">政府関係者（LEADER）</option>
                 <option value="MEMBER">一般メンバー</option>
+                <option value="LEADER">政府関係者（LEADER）</option>
               </select>
             </div>
             <button
@@ -130,7 +117,7 @@ export default function GroupDetailPage() {
               disabled={submitting}
               className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
             >
-              {submitting ? "登録中..." : "登録"}
+              {submitting ? "送信中..." : "招待を送る"}
             </button>
           </form>
           {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
@@ -140,15 +127,14 @@ export default function GroupDetailPage() {
         {/* 政府関係者一覧 */}
         <section>
           <h3 className="font-semibold text-gray-700 mb-3">
-            政府関係者（LEADER）{leaders.length > 0 && <span className="ml-2 text-gray-400 font-normal text-sm">{leaders.length}人</span>}
+            政府関係者（LEADER）
+            {leaders.length > 0 && <span className="ml-2 text-gray-400 font-normal text-sm">{leaders.length}人</span>}
           </h3>
           {leaders.length === 0 ? (
             <p className="text-gray-400 text-sm">政府関係者がいません。</p>
           ) : (
             <ul className="space-y-2">
-              {leaders.map((m) => (
-                <MemberRow key={m.id} member={m} />
-              ))}
+              {leaders.map((m) => <MemberRow key={m.id} member={m} />)}
             </ul>
           )}
         </section>
@@ -156,15 +142,14 @@ export default function GroupDetailPage() {
         {/* 一般メンバー一覧 */}
         <section>
           <h3 className="font-semibold text-gray-700 mb-3">
-            一般メンバー{regularMembers.length > 0 && <span className="ml-2 text-gray-400 font-normal text-sm">{regularMembers.length}人</span>}
+            一般メンバー
+            {regularMembers.length > 0 && <span className="ml-2 text-gray-400 font-normal text-sm">{regularMembers.length}人</span>}
           </h3>
           {regularMembers.length === 0 ? (
             <p className="text-gray-400 text-sm">一般メンバーがいません。</p>
           ) : (
             <ul className="space-y-2">
-              {regularMembers.map((m) => (
-                <MemberRow key={m.id} member={m} />
-              ))}
+              {regularMembers.map((m) => <MemberRow key={m.id} member={m} />)}
             </ul>
           )}
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { auth, signOut } from "@/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import InvitationList from "./InvitationList";
 
 export default async function HomePage() {
   const session = await auth();
@@ -42,6 +43,7 @@ export default async function HomePage() {
           </h2>
           <p className="text-gray-500">ログインに成功しました。</p>
         </div>
+
         <nav className="flex gap-4">
           <Link
             href="/groups"
@@ -50,6 +52,8 @@ export default async function HomePage() {
             グループ管理
           </Link>
         </nav>
+
+        <InvitationList />
       </main>
     </div>
   );

--- a/prisma/migrations/20260321000001_add_invitations/migration.sql
+++ b/prisma/migrations/20260321000001_add_invitations/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "InvitationStatus" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED');
+
+-- CreateTable
+CREATE TABLE "Invitation" (
+    "id" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "inviterId" TEXT NOT NULL,
+    "inviteeId" TEXT NOT NULL,
+    "role" "GroupRole" NOT NULL DEFAULT 'MEMBER',
+    "status" "InvitationStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Invitation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invitation_groupId_inviteeId_key" ON "Invitation"("groupId", "inviteeId");
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_inviterId_fkey" FOREIGN KEY ("inviterId") REFERENCES "GroupMember"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invitation" ADD CONSTRAINT "Invitation_inviteeId_fkey" FOREIGN KEY ("inviteeId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,9 +19,10 @@ model User {
   image         String?
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
-  accounts      Account[]
-  sessions      Session[]
-  groupMembers  GroupMember[]
+  accounts           Account[]
+  sessions           Session[]
+  groupMembers       GroupMember[]
+  receivedInvitations Invitation[]
 }
 
 // ─── グループ ───────────────────────────────────────────────
@@ -36,6 +37,7 @@ model Group {
   updatedAt         DateTime      @updatedAt
   members           GroupMember[]
   quests            Quest[]
+  invitations       Invitation[]
 }
 
 /// グループとユーザーの中間テーブル。ロールとメンバーポイント残高を保持。
@@ -50,8 +52,9 @@ model GroupMember {
   updatedAt    DateTime    @updatedAt
   user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   group        Group       @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  createdQuests  Quest[]   @relation("QuestCreator")
-  completedQuests Quest[]  @relation("QuestCompleter")
+  createdQuests   Quest[]      @relation("QuestCreator")
+  completedQuests Quest[]      @relation("QuestCompleter")
+  sentInvitations Invitation[]
 
   @@unique([userId, groupId])
 }
@@ -95,6 +98,35 @@ enum QuestStatus {
   IN_PROGRESS // 進行中
   COMPLETED   // 完了
   CANCELLED   // キャンセル
+}
+
+// ─── 招待 ────────────────────────────────────────────────────
+
+/// グループへの招待。LEADERが送り、招待されたユーザーが承認/拒否する。
+model Invitation {
+  id        String           @id @default(cuid())
+  groupId   String
+  /// 招待を送ったGroupMember.id（LEADER）
+  inviterId String
+  /// 招待されたUser.id
+  inviteeId String
+  /// 付与予定のロール
+  role      GroupRole        @default(MEMBER)
+  status    InvitationStatus @default(PENDING)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+  group     Group            @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  inviter   GroupMember      @relation(fields: [inviterId], references: [id], onDelete: Cascade)
+  invitee   User             @relation(fields: [inviteeId], references: [id], onDelete: Cascade)
+
+  /// 同じグループへの重複招待を防ぐ
+  @@unique([groupId, inviteeId])
+}
+
+enum InvitationStatus {
+  PENDING   // 未回答
+  ACCEPTED  // 承認済み
+  DECLINED  // 拒否済み
 }
 
 model Account {


### PR DESCRIPTION
## 概要
グループへの招待機能を追加します。

## 追加内容
- `Invitation` モデル（PENDING/ACCEPTED/DECLINED）
- `POST /api/groups/[id]/invitations` — LEADERが招待を送る
- `GET /api/invitations` — 自分宛の未回答招待一覧
- `PATCH /api/invitations/[id]` — 承認/拒否（承認時にGroupMemberを自動作成）
- グループ詳細ページを招待フォームに変更
- トップページに招待通知リストを追加