### PR TITLE
feat: クエスト発行機能を追加

### DIFF
--- a/app/api/groups/[id]/quests/route.ts
+++ b/app/api/groups/[id]/quests/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// クエスト一覧取得
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const { id: groupId } = await params;
+
+  const quests = await prisma.quest.findMany({
+    where: { groupId },
+    include: {
+      creator: { include: { user: { select: { id: true, name: true, email: true } } } },
+      completer: { include: { user: { select: { id: true, name: true, email: true } } } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(quests);
+}
+
+// クエスト作成
+// GOVERNMENT: ADMIN・LEADERのみ。政府の未割当ポイントから報酬を確保
+// MEMBER: 全員可。作成者の保有ポイントからエスクロー（即時引落）
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const { id: groupId } = await params;
+  const { title, description, pointReward, questType } = await req.json();
+
+  if (!title?.trim()) {
+    return NextResponse.json({ error: "タイトルは必須です" }, { status: 400 });
+  }
+  if (questType !== "GOVERNMENT" && questType !== "MEMBER") {
+    return NextResponse.json({ error: "questTypeはGOVERNMENTまたはMEMBERを指定してください" }, { status: 400 });
+  }
+  if (typeof pointReward !== "number" || !Number.isInteger(pointReward) || pointReward <= 0) {
+    return NextResponse.json({ error: "報酬は1以上の整数で指定してください" }, { status: 400 });
+  }
+
+  // 作成者のメンバー情報を取得
+  const creatorMember = await prisma.groupMember.findUnique({
+    where: { userId_groupId: { userId: session.user.id, groupId } },
+  });
+  if (!creatorMember) {
+    return NextResponse.json({ error: "グループのメンバーではありません" }, { status: 403 });
+  }
+
+  if (questType === "GOVERNMENT") {
+    // 政府案件：ADMIN・LEADERのみ作成可
+    if (creatorMember.role === "MEMBER") {
+      return NextResponse.json({ error: "政府案件の発行はADMIN・LEADERのみ実行できます" }, { status: 403 });
+    }
+
+    // 政府の未割当ポイントを計算
+    // 未割当 = 発行済み - 流通中 - 既存のオープン政府案件の報酬合計
+    const group = await prisma.group.findUnique({ where: { id: groupId } });
+    const members = await prisma.groupMember.findMany({ where: { groupId } });
+    const totalCirculating = members.reduce((sum, m) => sum + m.memberPoints, 0);
+    const activeGovQuests = await prisma.quest.findMany({
+      where: { groupId, questType: "GOVERNMENT", status: { in: ["OPEN", "IN_PROGRESS"] } },
+    });
+    const allocated = activeGovQuests.reduce((sum, q) => sum + q.pointReward, 0);
+    const available = group!.totalIssuedPoints - totalCirculating - allocated;
+
+    if (pointReward > available) {
+      return NextResponse.json(
+        { error: `政府の未割当ポイントが不足しています（残り ${available} pt）` },
+        { status: 400 }
+      );
+    }
+
+    const quest = await prisma.quest.create({
+      data: { groupId, creatorId: creatorMember.id, title: title.trim(), description: description?.trim() ?? null, pointReward, questType: "GOVERNMENT" },
+      include: {
+        creator: { include: { user: { select: { id: true, name: true, email: true } } } },
+        completer: { include: { user: { select: { id: true, name: true, email: true } } } },
+      },
+    });
+
+    return NextResponse.json(quest, { status: 201 });
+  }
+
+  // メンバー案件：作成者の保有ポイントからエスクロー
+  if (creatorMember.memberPoints < pointReward) {
+    return NextResponse.json(
+      { error: `保有ポイントが不足しています（残り ${creatorMember.memberPoints} pt）` },
+      { status: 400 }
+    );
+  }
+
+  const [quest] = await prisma.$transaction([
+    prisma.quest.create({
+      data: { groupId, creatorId: creatorMember.id, title: title.trim(), description: description?.trim() ?? null, pointReward, questType: "MEMBER" },
+      include: {
+        creator: { include: { user: { select: { id: true, name: true, email: true } } } },
+        completer: { include: { user: { select: { id: true, name: true, email: true } } } },
+      },
+    }),
+    prisma.groupMember.update({
+      where: { id: creatorMember.id },
+      data: { memberPoints: { decrement: pointReward } },
+    }),
+  ]);
+
+  return NextResponse.json(quest, { status: 201 });
+}

--- a/app/groups/[id]/page.tsx
+++ b/app/groups/[id]/page.tsx
@@ -104,6 +104,20 @@ export default function GroupDetailPage() {
           </div>
         </section>
 
+        {/* クエストへのリンク */}
+        <Link
+          href={`/groups/${id}/quests`}
+          className="block bg-white border border-gray-200 rounded-xl px-6 py-4 hover:shadow-md transition"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-semibold text-gray-800">クエスト</p>
+              <p className="text-xs text-gray-400 mt-0.5">政府案件・メンバー案件の一覧と発行</p>
+            </div>
+            <span className="text-gray-400">→</span>
+          </div>
+        </Link>
+
         {/* 政府発行済みポイント管理 */}
         <IssuedPointsEditor
           groupId={id}

--- a/app/groups/[id]/quests/page.tsx
+++ b/app/groups/[id]/quests/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+type Role = "ADMIN" | "LEADER" | "MEMBER";
+
+type QuestUser = { id: string; name: string | null; email: string };
+type QuestMember = { id: string; user: QuestUser };
+
+type Quest = {
+  id: string;
+  title: string;
+  description: string | null;
+  pointReward: number;
+  questType: "GOVERNMENT" | "MEMBER";
+  status: "OPEN" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+  creator: QuestMember;
+  completer: QuestMember | null;
+  createdAt: string;
+};
+
+type GroupMember = {
+  id: string;
+  role: Role;
+  memberPoints: number;
+  user: QuestUser;
+};
+
+const STATUS_LABEL: Record<Quest["status"], string> = {
+  OPEN: "受付中",
+  IN_PROGRESS: "進行中",
+  COMPLETED: "完了",
+  CANCELLED: "キャンセル",
+};
+
+const STATUS_COLOR: Record<Quest["status"], string> = {
+  OPEN: "bg-green-100 text-green-700",
+  IN_PROGRESS: "bg-yellow-100 text-yellow-700",
+  COMPLETED: "bg-gray-100 text-gray-500",
+  CANCELLED: "bg-red-100 text-red-500",
+};
+
+export default function QuestsPage() {
+  const { id: groupId } = useParams<{ id: string }>();
+  const [quests, setQuests] = useState<Quest[]>([]);
+  const [myMember, setMyMember] = useState<GroupMember | null>(null);
+  const [tab, setTab] = useState<"GOVERNMENT" | "MEMBER">("GOVERNMENT");
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/groups/${groupId}/quests`).then((r) => r.ok ? r.json() : []),
+      fetch("/api/me").then((r) => r.ok ? r.json() : null),
+      fetch("/api/groups").then((r) => r.ok ? r.json() : []),
+    ]).then(([questData, me, groups]) => {
+      if (Array.isArray(questData)) setQuests(questData);
+      if (me?.id && Array.isArray(groups)) {
+        const group = groups.find((g: { id: string; members: GroupMember[] }) => g.id === groupId);
+        const member = group?.members.find((m: GroupMember) => m.user.id === me.id);
+        if (member) setMyMember(member);
+      }
+    });
+  }, [groupId]);
+
+  const canCreateGov = myMember?.role === "ADMIN" || myMember?.role === "LEADER";
+  const filtered = quests.filter((q) => q.questType === tab);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
+          <h1 className="text-xl font-bold text-gray-800">Group Point</h1>
+          <Link href={`/groups/${groupId}`} className="text-sm text-gray-500 hover:text-gray-700">
+            ← グループに戻る
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold text-gray-800">クエスト一覧</h2>
+          {myMember && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition"
+            >
+              + クエストを発行
+            </button>
+          )}
+        </div>
+
+        {/* 保有ポイント表示 */}
+        {myMember && (
+          <p className="text-sm text-gray-500">
+            あなたの保有ポイント: <strong className="text-gray-800">{myMember.memberPoints} pt</strong>
+          </p>
+        )}
+
+        {/* 発行フォーム */}
+        {showForm && myMember && (
+          <CreateQuestForm
+            groupId={groupId}
+            canCreateGov={canCreateGov}
+            myPoints={myMember.memberPoints}
+            onCreated={(q) => {
+              setQuests((prev) => [q, ...prev]);
+              setShowForm(false);
+              setTab(q.questType);
+              // メンバー案件の場合は自分のポイントを更新
+              if (q.questType === "MEMBER") {
+                setMyMember((prev) => prev ? { ...prev, memberPoints: prev.memberPoints - q.pointReward } : prev);
+              }
+            }}
+            onCancel={() => setShowForm(false)}
+          />
+        )}
+
+        {/* タブ */}
+        <div className="flex gap-2 border-b border-gray-200">
+          {(["GOVERNMENT", "MEMBER"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition ${
+                tab === t
+                  ? "border-blue-600 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {t === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+              <span className="ml-1.5 text-xs text-gray-400">
+                {quests.filter((q) => q.questType === t).length}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* クエスト一覧 */}
+        {filtered.length === 0 ? (
+          <p className="text-gray-400 text-sm py-8 text-center">クエストがありません</p>
+        ) : (
+          <ul className="space-y-3">
+            {filtered.map((q) => <QuestCard key={q.id} quest={q} />)}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function QuestCard({ quest }: { quest: Quest }) {
+  return (
+    <li className="bg-white border border-gray-200 rounded-xl px-6 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${STATUS_COLOR[quest.status]}`}>
+              {STATUS_LABEL[quest.status]}
+            </span>
+            <span className="text-xs text-gray-400">
+              by {quest.creator.user.name ?? quest.creator.user.email}
+            </span>
+          </div>
+          <p className="font-medium text-gray-800">{quest.title}</p>
+          {quest.description && (
+            <p className="text-sm text-gray-500 mt-1">{quest.description}</p>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          <p className="text-lg font-bold text-blue-600">{quest.pointReward} pt</p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function CreateQuestForm({
+  groupId,
+  canCreateGov,
+  myPoints,
+  onCreated,
+  onCancel,
+}: {
+  groupId: string;
+  canCreateGov: boolean;
+  myPoints: number;
+  onCreated: (q: Quest) => void;
+  onCancel: () => void;
+}) {
+  const [questType, setQuestType] = useState<"GOVERNMENT" | "MEMBER">(
+    canCreateGov ? "GOVERNMENT" : "MEMBER"
+  );
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [pointReward, setPointReward] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/groups/${groupId}/quests`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, description, pointReward, questType }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "エラーが発生しました");
+        return;
+      }
+      onCreated(data);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="bg-white border border-blue-200 rounded-xl p-6 space-y-4">
+      <h3 className="font-semibold text-gray-800">クエストを発行</h3>
+
+      {/* 案件種別 */}
+      <div className="flex gap-3">
+        {canCreateGov && (
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              value="GOVERNMENT"
+              checked={questType === "GOVERNMENT"}
+              onChange={() => setQuestType("GOVERNMENT")}
+            />
+            <span className="text-sm">政府案件</span>
+          </label>
+        )}
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            value="MEMBER"
+            checked={questType === "MEMBER"}
+            onChange={() => setQuestType("MEMBER")}
+          />
+          <span className="text-sm">メンバー案件</span>
+        </label>
+      </div>
+
+      {questType === "MEMBER" && (
+        <p className="text-xs text-gray-400">
+          ※ 報酬は作成時にあなたの保有ポイント（{myPoints} pt）から引き落とされます
+        </p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="タイトル"
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+          required
+        />
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="説明（任意）"
+          rows={2}
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none"
+        />
+        <div className="flex items-center gap-3">
+          <input
+            type="number"
+            value={pointReward || ""}
+            onChange={(e) => setPointReward(Number(e.target.value))}
+            placeholder="報酬"
+            min={1}
+            max={questType === "MEMBER" ? myPoints : undefined}
+            className="w-32 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            required
+          />
+          <span className="text-sm text-gray-500">pt</span>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+          >
+            {submitting ? "発行中..." : "発行する"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-5 py-2 text-sm text-gray-500 hover:text-gray-700 transition"
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -83,11 +83,52 @@ async function main() {
     });
   }
 
+  const memberRecords: { id: string }[] = [];
   for (const member of members) {
-    await prisma.groupMember.upsert({
+    const m = await prisma.groupMember.upsert({
       where: { userId_groupId: { userId: member.id, groupId: group.id } },
       update: {},
-      create: { userId: member.id, groupId: group.id, role: "MEMBER", memberPoints: 0 },
+      create: { userId: member.id, groupId: group.id, role: "MEMBER", memberPoints: 100 },
+    });
+    memberRecords.push(m);
+  }
+
+  // ── クエスト作成 ──────────────────────────────────────────
+  const adminMember = await prisma.groupMember.findUnique({
+    where: { userId_groupId: { userId: admin.id, groupId: group.id } },
+  });
+  const leaderMembers = await Promise.all(
+    leaders.map((l) =>
+      prisma.groupMember.findUnique({
+        where: { userId_groupId: { userId: l.id, groupId: group.id } },
+      })
+    )
+  );
+
+  // 政府案件
+  const govQuests = [
+    { title: "道路の補修作業", description: "市内の主要道路のひび割れを修繕してください", pointReward: 200 },
+    { title: "公園の清掃活動", description: "市民公園のゴミ拾いと草刈りを行ってください", pointReward: 100 },
+    { title: "防災訓練の補助", description: "地域防災訓練のスタッフとして参加してください", pointReward: 150 },
+  ];
+  for (const q of govQuests) {
+    await prisma.quest.create({
+      data: { ...q, groupId: group.id, creatorId: adminMember!.id, questType: "GOVERNMENT" },
+    });
+  }
+
+  // メンバー案件（leader1が発行）
+  const memberQuests = [
+    { title: "引越しの手伝い", description: "来週末の引越しを手伝ってください", pointReward: 50 },
+    { title: "英語の翻訳", description: "書類1枚の日本語→英語翻訳をお願いします", pointReward: 30 },
+  ];
+  for (const q of memberQuests) {
+    await prisma.quest.create({
+      data: { ...q, groupId: group.id, creatorId: leaderMembers[0]!.id, questType: "MEMBER" },
+    });
+    await prisma.groupMember.update({
+      where: { id: leaderMembers[0]!.id },
+      data: { memberPoints: { decrement: q.pointReward } },
     });
   }
 
@@ -96,6 +137,7 @@ async function main() {
   console.log("   ADMIN  :", admin.email);
   console.log("   LEADER :", leaders.map((l) => l.email).join(", "));
   console.log("   MEMBER :", members.map((m) => m.email).join(", "));
+  console.log("   政府案件: 3件 / メンバー案件: 2件");
   console.log("   パスワード: password123");
 }
 


### PR DESCRIPTION
## 概要
政府案件・メンバー案件のクエスト発行機能を追加します。

## 変更内容

### API
- `GET /api/groups/[id]/quests`: クエスト一覧取得
- `POST /api/groups/[id]/quests`: クエスト作成
  - **政府案件**: ADMIN・LEADERのみ。政府の未割当ポイントから報酬を確保
  - **メンバー案件**: 全員可。作成時に報酬を保有ポイントからエスクロー（即時引落）

### ページ
- `/groups/[id]/quests`: クエスト一覧・発行ページ
  - 政府案件・メンバー案件タブ切替
  - ロールに応じて案件種別の選択肢を制御

### シードデータ
- 政府案件3件・メンバー案件2件を追加
- 一般メンバーの初期保有ポイントを100ptに設定