### PR TITLE
feat: ADMINによるポイント直接付与機能を追加

### DIFF
--- a/app/api/groups/[id]/grant/route.ts
+++ b/app/api/groups/[id]/grant/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// ポイントを直接付与する（ADMINのみ）
+// 政府の未割当ポイント（発行済み - 流通中 - 政府案件の報酬合計）から充当する
+// body: { amount: number, memberId?: string }
+//   memberId あり → 個人付与
+//   memberId なし → グループ全員に付与（合計 = amount × 人数）
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  const { id: groupId } = await params;
+  const { amount, memberId } = await req.json();
+
+  if (typeof amount !== "number" || !Number.isInteger(amount) || amount <= 0) {
+    return NextResponse.json({ error: "付与量は1以上の整数で指定してください" }, { status: 400 });
+  }
+
+  // ADMINのみ操作可能
+  const operator = await prisma.groupMember.findUnique({
+    where: { userId_groupId: { userId: session.user.id, groupId } },
+  });
+  if (!operator || operator.role !== "ADMIN") {
+    return NextResponse.json({ error: "ポイント付与はADMINのみ実行できます" }, { status: 403 });
+  }
+
+  // 未割当ポイントを計算
+  const group = await prisma.group.findUnique({ where: { id: groupId } });
+  if (!group) return NextResponse.json({ error: "グループが見つかりません" }, { status: 404 });
+
+  const allMembers = await prisma.groupMember.findMany({ where: { groupId } });
+  const totalCirculating = allMembers.reduce((sum, m) => sum + m.memberPoints, 0);
+  const activeGovQuests = await prisma.quest.findMany({
+    where: { groupId, questType: "GOVERNMENT", status: { in: ["OPEN", "IN_PROGRESS"] } },
+  });
+  const allocated = activeGovQuests.reduce((sum, q) => sum + q.pointReward, 0);
+  const available = group.totalIssuedPoints - totalCirculating - allocated;
+
+  if (memberId) {
+    // ── 個人付与 ──────────────────────────────────────────
+    const target = await prisma.groupMember.findUnique({ where: { id: memberId } });
+    if (!target || target.groupId !== groupId) {
+      return NextResponse.json({ error: "メンバーが見つかりません" }, { status: 404 });
+    }
+    if (amount > available) {
+      return NextResponse.json(
+        { error: `未割当ポイントが不足しています（残り ${available} pt）` },
+        { status: 400 }
+      );
+    }
+    const updated = await prisma.groupMember.update({
+      where: { id: memberId },
+      data: { memberPoints: { increment: amount } },
+      include: { user: { select: { id: true, name: true, email: true } } },
+    });
+    return NextResponse.json({ type: "individual", updated });
+  } else {
+    // ── 全員付与 ──────────────────────────────────────────
+    const targets = allMembers.filter((m) => m.id !== operator.id); // ADMIN自身は除外するか含めるか？→含める
+    const totalCost = amount * allMembers.length;
+    if (totalCost > available) {
+      return NextResponse.json(
+        { error: `未割当ポイントが不足しています（必要: ${totalCost} pt、残り: ${available} pt）` },
+        { status: 400 }
+      );
+    }
+    await prisma.groupMember.updateMany({
+      where: { groupId },
+      data: { memberPoints: { increment: amount } },
+    });
+    return NextResponse.json({ type: "all", totalGranted: totalCost, memberCount: allMembers.length });
+  }
+}

--- a/app/groups/[id]/page.tsx
+++ b/app/groups/[id]/page.tsx
@@ -155,6 +155,27 @@ export default function GroupDetailPage() {
           onRemoved={removeMember}
           inviteRole={myRole === "ADMIN" || myRole === "LEADER" ? "MEMBER" : undefined}
         />
+
+        {/* ポイント付与（ADMINのみ） */}
+        {myRole === "ADMIN" && (
+          <GrantPointsSection
+            groupId={id}
+            members={group.members}
+            onGranted={(memberId, amount) => {
+              setGroup((prev) => {
+                if (!prev) return prev;
+                return {
+                  ...prev,
+                  members: prev.members.map((m) =>
+                    memberId === null || m.id === memberId
+                      ? { ...m, memberPoints: m.memberPoints + amount }
+                      : m
+                  ),
+                };
+              });
+            }}
+          />
+        )}
       </main>
     </div>
   );
@@ -383,6 +404,124 @@ function IssuedPointsEditor({
           />
         </div>
       )}
+    </section>
+  );
+}
+
+function GrantPointsSection({
+  groupId,
+  members,
+  onGranted,
+}: {
+  groupId: string;
+  members: Member[];
+  onGranted: (memberId: string | null, amount: number) => void;
+}) {
+  const [mode, setMode] = useState<"individual" | "all">("individual");
+  const [selectedMemberId, setSelectedMemberId] = useState(members[0]?.id ?? "");
+  const [amount, setAmount] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    if (amount <= 0) return;
+    setSubmitting(true);
+    try {
+      const body: { amount: number; memberId?: string } = { amount };
+      if (mode === "individual") body.memberId = selectedMemberId;
+      const res = await fetch(`/api/groups/${groupId}/grant`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "エラーが発生しました");
+        return;
+      }
+      if (mode === "individual") {
+        onGranted(selectedMemberId, amount);
+        setSuccess(`${amount} pt を付与しました`);
+      } else {
+        onGranted(null, amount);
+        setSuccess(`全員に ${amount} pt を付与しました（合計 ${data.totalGranted} pt）`);
+      }
+      setAmount(0);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-4">
+      <h3 className="font-semibold text-gray-800">ポイント付与（ADMIN）</h3>
+
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2 cursor-pointer text-sm">
+          <input
+            type="radio"
+            checked={mode === "individual"}
+            onChange={() => setMode("individual")}
+          />
+          個人に付与
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer text-sm">
+          <input
+            type="radio"
+            checked={mode === "all"}
+            onChange={() => setMode("all")}
+          />
+          全員に付与
+        </label>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-wrap gap-3 items-end">
+        {mode === "individual" && (
+          <div>
+            <p className="text-xs text-gray-500 mb-1">対象メンバー</p>
+            <select
+              value={selectedMemberId}
+              onChange={(e) => setSelectedMemberId(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              {members.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.user.name ?? m.user.email}（{m.memberPoints} pt）
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <div>
+          <p className="text-xs text-gray-500 mb-1">付与量</p>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              value={amount || ""}
+              onChange={(e) => setAmount(Number(e.target.value))}
+              placeholder="pt"
+              className="w-28 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              required
+            />
+            <span className="text-sm text-gray-500">pt</span>
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-5 py-2 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700 disabled:opacity-50 transition"
+        >
+          {submitting ? "付与中..." : "付与する"}
+        </button>
+      </form>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {success && <p className="text-sm text-green-600">{success}</p>}
     </section>
   );
 }


### PR DESCRIPTION
## 概要

クエストをクリアしなくても、ADMINがメンバーへポイントを直接付与できる機能を追加。

## 変更内容

- `POST /api/groups/[id]/grant` エンドポイントを新規実装
  - `{ amount, memberId }` で個人付与、`memberId` 省略で全員一括付与
  - ADMINのみ実行可能
  - 政府の未割当ポイント（発行済み - 流通中 - 政府案件allocatedの合計）から充当
  - ポイント不足時は400エラーを返す
- グループ詳細ページ (`/groups/[id]`) にADMIN向け「ポイント付与」セクションを追加
  - 個人付与・全員付与をラジオボタンで切替
  - 個人付与時はメンバーをセレクトボックスで選択

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)