### PR TITLE
feat: クエスト発行時点で流通中ポイントを増加させる

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -126,13 +126,14 @@ export default function GroupDetailPage() {
   );
 
   const totalMyItems = myAcceptedQuests.length + myActiveSubQuests.length;
-  // 合計5件になるよう配分（クエスト優先）
-  const questSlots = Math.min(myAcceptedQuests.length, 5);
-  const subQuestSlots = Math.min(myActiveSubQuests.length, 5 - questSlots);
-  const displayedQuests = myAcceptedQuests.slice(0, questSlots);
-  const displayedSubQuests = myActiveSubQuests.slice(0, subQuestSlots);
+  const displayedQuests = myAcceptedQuests.slice(0, 3);
+  const displayedSubQuests = myActiveSubQuests.slice(0, 3);
 
-  const totalCirculating = group.members.reduce((sum, m) => sum + m.memberPoints, 0);
+  const memberPointsTotal = group.members.reduce((sum, m) => sum + m.memberPoints, 0);
+  const allocatedQuestPoints = quests
+    .filter((q) => q.questType === "GOVERNMENT" && (q.status === "OPEN" || q.status === "IN_PROGRESS"))
+    .reduce((sum, q) => sum + q.pointReward, 0);
+  const totalCirculating = memberPointsTotal + allocatedQuestPoints;
 
   function removeMember(removedId: string) {
     setGroup((prev) =>
@@ -229,7 +230,7 @@ export default function GroupDetailPage() {
                   </div>
                 </div>
               )}
-              {totalMyItems > 5 && (
+              {totalMyItems > 3 && (
                 <Link
                   href={`/groups/${id}/quests`}
                   className="block text-xs text-blue-500 hover:text-blue-700 text-right pt-2"

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -40,10 +40,16 @@ export async function PATCH(
     return NextResponse.json({ error: "発行済みポイントが0を下回ることはできません" }, { status: 400 });
   }
 
-  // 回収の場合：流通中ポイントを下回れない
+  // 回収の場合：流通中ポイント（メンバー保有 + アクティブ案件割当）を下回れない
   if (delta < 0) {
     const members = await prisma.groupMember.findMany({ where: { groupId } });
-    const totalCirculating = members.reduce((sum, m) => sum + m.memberPoints, 0);
+    const memberPointsTotal = members.reduce((sum, m) => sum + m.memberPoints, 0);
+    const activeGovQuests = await prisma.quest.findMany({
+      where: { groupId, questType: "GOVERNMENT", status: { in: ["OPEN", "IN_PROGRESS"] } },
+      select: { pointReward: true },
+    });
+    const allocatedQuestPoints = activeGovQuests.reduce((sum, q) => sum + q.pointReward, 0);
+    const totalCirculating = memberPointsTotal + allocatedQuestPoints;
     if (newTotal < totalCirculating) {
       const reclaimable = group.totalIssuedPoints - totalCirculating;
       return NextResponse.json(


### PR DESCRIPTION
## 変更内容

- 政府案件の流通中ポイント計算に、アクティブ案件（OPEN/IN_PROGRESS）の報酬合計を含めるよう変更
- これにより案件発行時点で未流通が即時減少し、流通中が増加する
- 案件完了時は報酬がメンバーの保有ポイントに移るだけなので流通中の合計は変わらない
- 回収APIのバリデーションも同様にアクティブ案件割当分を保護するよう修正