### PR TITLE
fix: 人・日・週・月の換算式を修正

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -26,8 +26,8 @@ type Group = {
 
 // timeUnit: YEN=円のまま表示、HOUR/DAY/WEEK/MONTH=人・時間換算
 const TIME_UNIT_LABEL: Record<string, string> = { YEN: "円", HOUR: "人・時間", DAY: "人・日", WEEK: "人・週", MONTH: "人・月" };
-// 人・時間 = pt ÷ 人件費、人・日 = 人・時間 × 8、人・週 = 人・日 × 5、人・月 = 人・週 × 4
-const TIME_UNIT_MULTIPLIER: Record<string, number> = { HOUR: 1, DAY: 8, WEEK: 8 * 5, MONTH: 8 * 5 * 4 };
+// 人・時間 = pt ÷ 人件費、人・日 = 人・時間 ÷ 8、人・週 = 人・日 ÷ 5、人・月 = 人・週 ÷ 4
+const TIME_UNIT_MULTIPLIER: Record<string, number> = { HOUR: 1, DAY: 1 / 8, WEEK: 1 / (8 * 5), MONTH: 1 / (8 * 5 * 4) };
 
 // ポイントを表示用にフォーマット
 function formatPoint(points: number, group: Pick<Group, "pointUnit" | "laborCostPerHour" | "timeUnit">): string {


### PR DESCRIPTION
## 変更内容

- 人・日・週・月への換算式を掛け算から割り算に修正
  - 人・日 = 人・時間 ÷ 8
  - 人・週 = 人・時間 ÷ 40
  - 人・月 = 人・時間 ÷ 160