### PR TITLE
feat: ポイント付与フォームに単位選択ドロップダウンを追加

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -749,12 +749,17 @@ function GrantPointsSection({
   const [mode, setMode] = useState<"individual" | "all">("individual");
   const [selectedMemberId, setSelectedMemberId] = useState(members[0]?.id ?? "");
   const [amount, setAmount] = useState(0);
+  const [selectedInputUnit, setSelectedInputUnit] = useState(group.timeUnit);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
-  const unitLabel = inputUnitLabel(group);
-  const isDecimalUnit = group.pointUnit === "円" && group.timeUnit !== "YEN" && group.laborCostPerHour > 0;
+  // 入力単位の切り替えが可能か（円表示 & 人件費設定済みの場合）
+  const canSelectUnit = group.pointUnit === "円" && group.laborCostPerHour > 0;
+  // 現在選択中の単位でのグループ設定（変換に使用）
+  const inputGroup = { ...group, timeUnit: canSelectUnit ? selectedInputUnit : group.timeUnit };
+  const unitLabel = inputUnitLabel(inputGroup);
+  const isDecimalUnit = inputGroup.pointUnit === "円" && inputGroup.timeUnit !== "YEN" && inputGroup.laborCostPerHour > 0;
   const step = isDecimalUnit ? 0.01 : 1;
 
   async function handleSubmit(e: React.FormEvent) {
@@ -762,7 +767,7 @@ function GrantPointsSection({
     setError("");
     setSuccess("");
     if (amount <= 0) return;
-    const ptAmount = unitToPt(amount, group);
+    const ptAmount = unitToPt(amount, inputGroup);
     setSubmitting(true);
     try {
       const body: { amount: number; memberId?: string } = { amount: ptAmount };
@@ -843,7 +848,19 @@ function GrantPointsSection({
               className="w-28 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
               required
             />
-            <span className="text-sm text-gray-500">{unitLabel}</span>
+            {canSelectUnit ? (
+              <select
+                value={selectedInputUnit}
+                onChange={(e) => { setSelectedInputUnit(e.target.value); setAmount(0); }}
+                className="border border-gray-300 rounded-lg px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              >
+                {Object.entries(TIME_UNIT_LABEL).map(([k, v]) => (
+                  <option key={k} value={k}>{v}</option>
+                ))}
+              </select>
+            ) : (
+              <span className="text-sm text-gray-500">{unitLabel}</span>
+            )}
           </div>
         </div>
         <button


### PR DESCRIPTION
## 概要

ポイント付与フォームで、グループの表示設定に関わらず任意の単位（円 / 人・時間 / 人・日 / 人・週 / 人・月）で付与量を入力できるようにしました。

## 変更内容

- 付与量入力欄の横に単位選択ドロップダウンを追加（円表示 & 人件費設定済みの場合のみ表示）
- 選択した単位に応じてステップ値・プレースホルダーが切り替わる
- 入力値はAPIへ送る前に pt に変換

## 関連コミット

- `feat: 発行・回収・付与の入力を設定単位（pt/円/人・時間等）に対応`
- `feat: ポイント付与セクションを政府発行済みポイントの直下に移動`
- `feat: ポイント付与フォームに単位選択ドロップダウンを追加`

🤖 Generated with [Claude Code](https://claude.com/claude-code)