### PR TITLE
fix: 政府クエスト完了時のボーナス二重減算バグを修正

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -534,7 +534,7 @@ function IssuedPointsEditor({
   onUpdated: (v: number) => void;
   onSettingsUpdated: (s: Partial<Pick<Group, "pointUnit" | "laborCostPerHour" | "timeUnit">>) => void;
 }) {
-  const reclaimable = totalIssuedPoints;
+  const reclaimable = totalIssuedPoints - totalCirculating;
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [pointUnit, setPointUnit] = useState(group.pointUnit);
   const [laborCost, setLaborCost] = useState(group.laborCostPerHour);

--- a/app/api/groups/[id]/quests/[questId]/complete/route.ts
+++ b/app/api/groups/[id]/quests/[questId]/complete/route.ts
@@ -150,12 +150,6 @@ export async function POST(_req: Request, { params }: Params) {
         where: { id: quest.creatorId },
         data: { memberPoints: { decrement: totalPayout } },
       });
-    } else if (quest.questType === "GOVERNMENT") {
-      // 政府案件: 実際の支払額をグループの発行済みポイントから差し引く
-      await tx.group.update({
-        where: { id: groupId },
-        data: { totalIssuedPoints: { decrement: totalPayout } },
-      });
     }
   });
 

--- a/app/api/groups/[id]/quests/route.ts
+++ b/app/api/groups/[id]/quests/route.ts
@@ -67,13 +67,15 @@ export async function POST(
     }
 
     // 政府の未割当ポイントを計算
-    // 未割当 = 残り予算（totalIssuedPoints）- 既存のオープン政府案件の報酬合計
+    // 未割当 = 発行済み - 流通中（memberPoints合計）- 既存のオープン政府案件の報酬合計（escrow）
     const group = await prisma.group.findUnique({ where: { id: groupId } });
+    const members = await prisma.groupMember.findMany({ where: { groupId } });
+    const totalCirculating = members.reduce((sum, m) => sum + m.memberPoints, 0);
     const activeGovQuests = await prisma.quest.findMany({
       where: { groupId, questType: "GOVERNMENT", status: { in: ["OPEN", "IN_PROGRESS"] } },
     });
     const allocated = activeGovQuests.reduce((sum, q) => sum + q.pointReward, 0);
-    const available = group!.totalIssuedPoints - allocated;
+    const available = group!.totalIssuedPoints - totalCirculating - allocated;
 
     if (pointReward > available) {
       return NextResponse.json(


### PR DESCRIPTION
## 問題

政府クエスト完了時にボーナス分が正しく政府予算から引かれていなかった。

## 原因

完了処理で `totalIssuedPoints -= totalPayout`（正しい）かつ `memberPoints += totalPayout`（正しい）の両方を実施していたが、`reclaimable = totalIssuedPoints - totalCirculating` の計算で両方の減少が重なり **2倍の減算**になっていた。

## 修正

- `reclaimable` の表示を `totalIssuedPoints` に変更（残り政府予算を直接表示）
- 政府クエスト作成時の `available` 計算から `totalCirculating` を除外（`totalIssuedPoints - allocated` に簡略化）
- `totalIssuedPoints` は完了時にベース＋ボーナス分が正しく引かれる

Closes #40