### PR TITLE
feat: クエスト提案承認時の一律報酬機能を追加

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -21,6 +21,7 @@ type Group = {
   pointUnit: string;
   laborCostPerHour: number;
   timeUnit: string;
+  proposalReward: number;
   members: Member[];
 };
 
@@ -317,6 +318,15 @@ export default function GroupDetailPage() {
             <span className="text-gray-400">→</span>
           </div>
         </Link>
+
+        {/* 提案報酬設定（ADMIN/LEADERのみ） */}
+        {(myRole === "ADMIN" || myRole === "LEADER") && (
+          <ProposalRewardEditor
+            groupId={id}
+            proposalReward={group.proposalReward}
+            onUpdated={(v) => setGroup((prev) => prev ? { ...prev, proposalReward: v } : prev)}
+          />
+        )}
 
         {/* 政府発行済みポイント管理（ADMIN/LEADERのみ） */}
         {group.totalIssuedPoints !== undefined && (
@@ -951,5 +961,82 @@ function DeltaForm({
       </form>
       {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
     </div>
+  );
+}
+
+function ProposalRewardEditor({
+  groupId,
+  proposalReward,
+  onUpdated,
+}: {
+  groupId: string;
+  proposalReward: number;
+  onUpdated: (v: number) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(proposalReward);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/groups/${groupId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ proposalReward: value }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? "エラーが発生しました"); return; }
+      onUpdated(data.proposalReward);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold text-gray-800">クエスト提案報酬</h3>
+          <p className="text-xs text-gray-400 mt-0.5">提案が承認されたときに提案者へ付与する一律ポイント</p>
+        </div>
+        <button
+          onClick={() => { setEditing((v) => !v); setValue(proposalReward); setError(""); }}
+          className="text-xs text-gray-400 hover:text-gray-600 transition"
+        >
+          {editing ? "キャンセル" : "変更"}
+        </button>
+      </div>
+
+      {!editing ? (
+        <p className="text-2xl font-bold text-blue-600">
+          {proposalReward} <span className="text-sm font-normal text-gray-500">pt</span>
+        </p>
+      ) : (
+        <form onSubmit={handleSave} className="flex items-center gap-3">
+          <input
+            type="number"
+            min={0}
+            value={value}
+            onChange={(e) => setValue(Number(e.target.value))}
+            className="w-28 border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            required
+          />
+          <span className="text-sm text-gray-500">pt</span>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+          >
+            {saving ? "保存中..." : "保存"}
+          </button>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </form>
+      )}
+    </section>
   );
 }

--- a/app/api/groups/[id]/quest-proposals/[proposalId]/approve/route.ts
+++ b/app/api/groups/[id]/quest-proposals/[proposalId]/approve/route.ts
@@ -42,6 +42,7 @@ export async function POST(
   const description: string | null = body.description !== undefined ? (body.description?.trim() || null) : proposal.description;
 
   const group = await prisma.group.findUnique({ where: { id: groupId } });
+  const proposalReward = group!.proposalReward;
   const members = await prisma.groupMember.findMany({ where: { groupId } });
   const totalCirculating = members.reduce((sum, m) => sum + m.memberPoints, 0);
   const activeGovQuests = await prisma.quest.findMany({
@@ -73,6 +74,14 @@ export async function POST(
       completer: { include: { user: { select: { id: true, name: true, email: true } } } },
     },
   });
+
+  // 提案者に一律報酬を付与
+  if (proposalReward > 0) {
+    await prisma.groupMember.update({
+      where: { id: proposal.proposerId },
+      data: { memberPoints: { increment: proposalReward } },
+    });
+  }
 
   const updatedProposal = await prisma.questProposal.update({
     where: { id: proposalId },

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -16,17 +16,27 @@ export async function PATCH(
 
   const { id: groupId } = await params;
   const body = await req.json();
-  const { delta, pointUnit, laborCostPerHour, timeUnit } = body;
+  const { delta, pointUnit, laborCostPerHour, timeUnit, proposalReward } = body;
 
-  // グループ表示設定の更新（ADMINのみ）
-  if (pointUnit !== undefined || laborCostPerHour !== undefined || timeUnit !== undefined) {
+  // グループ表示設定の更新（ADMINのみ）/ 提案報酬設定（ADMIN/LEADER）
+  if (pointUnit !== undefined || laborCostPerHour !== undefined || timeUnit !== undefined || proposalReward !== undefined) {
     const operator = await prisma.groupMember.findUnique({
       where: { userId_groupId: { userId: session.user.id, groupId } },
     });
-    if (!operator || operator.role !== "ADMIN") {
-      return NextResponse.json({ error: "設定変更はADMINのみ実行できます" }, { status: 403 });
+    if (!operator || operator.role === "MEMBER") {
+      return NextResponse.json({ error: "設定変更はADMIN・LEADERのみ実行できます" }, { status: 403 });
+    }
+    // 表示設定（pointUnit / laborCostPerHour / timeUnit）はADMINのみ
+    if ((pointUnit !== undefined || laborCostPerHour !== undefined || timeUnit !== undefined) && operator.role !== "ADMIN") {
+      return NextResponse.json({ error: "表示設定変更はADMINのみ実行できます" }, { status: 403 });
     }
     const data: Record<string, unknown> = {};
+    if (proposalReward !== undefined) {
+      if (typeof proposalReward !== "number" || !Number.isInteger(proposalReward) || proposalReward < 0) {
+        return NextResponse.json({ error: "提案報酬は0以上の整数で指定してください" }, { status: 400 });
+      }
+      data.proposalReward = proposalReward;
+    }
     if (pointUnit !== undefined) {
       if (!["pt", "円"].includes(pointUnit)) {
         return NextResponse.json({ error: "pointUnitはptまたは円を指定してください" }, { status: 400 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model Group {
   laborCostPerHour  Int           @default(0)
   /// 1ptが表す時間単位: "HOUR"=時間, "WEEK"=週, "MONTH"=月
   timeUnit          String        @default("HOUR")
+  /// クエスト提案が承認されたときに提案者へ付与する一律報酬ポイント
+  proposalReward    Int           @default(0)
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
   members           GroupMember[]


### PR DESCRIPTION
## 概要

クエスト提案が承認された際に、提案者へ一律ポイントを付与する機能を実装しました。

## 変更内容

### スキーマ
- `Group` に `proposalReward Int @default(0)` を追加

### API
- `PATCH /api/groups/[id]`: ADMIN/LEADERが `proposalReward` を設定可能に
- `POST /api/groups/[id]/quest-proposals/[proposalId]/approve`: 承認時に `group.proposalReward > 0` であれば提案者の `memberPoints` に自動付与

### UI
- グループ詳細ページ（ADMIN/LEADER向け）に「クエスト提案報酬」セクションを追加
  - 現在の報酬ポイントを表示
  - 「変更」ボタンから報酬額を編集・保存可能

## 動作フロー
1. ADMIN/LEADERがグループ詳細の「クエスト提案報酬」で金額を設定（例: 10pt）
2. メンバーがクエストを提案
3. ADMIN/LEADERが提案を承認
4. 提案者の保有ポイントに設定した報酬ポイントが自動付与される

Closes #