### PR TITLE
feat: 「政府」という文言を「管理側」に統一

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -124,7 +124,7 @@ const SUB_STATUS_COLOR: Record<SubQuest["status"], string> = {
 
 const ROLE_LABEL: Record<Role, string> = {
   ADMIN: "管理人",
-  LEADER: "政府関係者",
+  LEADER: "管理側メンバー",
   MEMBER: "一般メンバー",
 };
 
@@ -299,7 +299,7 @@ export default function GroupDetailPage() {
           <div className="flex items-center justify-between">
             <div>
               <p className="font-semibold text-gray-800">クエスト</p>
-              <p className="text-xs text-gray-400 mt-0.5">政府案件・メンバー案件の一覧と発行</p>
+              <p className="text-xs text-gray-400 mt-0.5">管理側案件・メンバー案件の一覧と発行</p>
             </div>
             <span className="text-gray-400">→</span>
           </div>
@@ -329,7 +329,7 @@ export default function GroupDetailPage() {
           />
         )}
 
-        {/* 政府発行済みポイント管理（ADMIN/LEADERのみ） */}
+        {/* 管理側発行済みポイント管理（ADMIN/LEADERのみ） */}
         {group.totalIssuedPoints !== undefined && (
           <IssuedPointsEditor
             groupId={id}
@@ -491,7 +491,7 @@ function InviteForm({ groupId, role }: { groupId: string; role: "LEADER" | "MEMB
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
-  const label = role === "LEADER" ? "政府関係者を招待" : "一般メンバーを招待";
+  const label = role === "LEADER" ? "管理側メンバーを招待" : "一般メンバーを招待";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -610,7 +610,7 @@ function IssuedPointsEditor({
   return (
     <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-5">
       <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-gray-800">政府発行済みポイント</h3>
+        <h3 className="font-semibold text-gray-800">管理側発行済みポイント</h3>
         {isAdmin && (
           <button
             onClick={() => setSettingsOpen((v) => !v)}

--- a/app/(app)/groups/[id]/quests/[questId]/page.tsx
+++ b/app/(app)/groups/[id]/quests/[questId]/page.tsx
@@ -209,7 +209,7 @@ export default function QuestDetailPage() {
             {STATUS_LABEL[quest.status]}
           </span>
           <span className="text-xs text-gray-400">
-            {quest.questType === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+            {quest.questType === "GOVERNMENT" ? "管理側案件" : "メンバー案件"}
           </span>
         </div>
 
@@ -277,7 +277,7 @@ export default function QuestDetailPage() {
           <div className="flex justify-between">
             <dt className="text-gray-400">支払者</dt>
             <dd className="text-gray-700 font-medium">
-              {quest.questType === "GOVERNMENT" ? "政府" : quest.creator.user.name ?? quest.creator.user.email}
+              {quest.questType === "GOVERNMENT" ? "管理側" : quest.creator.user.name ?? quest.creator.user.email}
             </dd>
           </div>
           <div className="flex justify-between">

--- a/app/(app)/groups/[id]/quests/page.tsx
+++ b/app/(app)/groups/[id]/quests/page.tsx
@@ -105,7 +105,7 @@ export default function QuestsPage() {
                     : "text-gray-600 border-gray-300 hover:border-blue-400"
                 }`}
               >
-                {f === "ALL" ? "種別：すべて" : f === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+                {f === "ALL" ? "種別：すべて" : f === "GOVERNMENT" ? "管理側案件" : "メンバー案件"}
               </button>
             ))}
             {myMember && (
@@ -173,7 +173,7 @@ function QuestCard({ quest, groupId }: { quest: Quest; groupId: string }) {
               {STATUS_LABEL[quest.status]}
             </span>
             <span className="text-xs text-gray-400">
-              {quest.questType === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+              {quest.questType === "GOVERNMENT" ? "管理側案件" : "メンバー案件"}
             </span>
             {quest.deadline && (
               <span className={`text-xs ${isOverdue ? "text-red-500 font-medium" : "text-gray-400"}`}>
@@ -248,7 +248,7 @@ function CreateQuestForm({
               checked={questType === "GOVERNMENT"}
               onChange={() => setQuestType("GOVERNMENT")}
             />
-            <span className="text-sm">政府案件</span>
+            <span className="text-sm">管理側案件</span>
           </label>
         )}
         <label className="flex items-center gap-2 cursor-pointer">

--- a/app/(app)/groups/page.tsx
+++ b/app/(app)/groups/page.tsx
@@ -95,7 +95,7 @@ export default function GroupsPage() {
                   </div>
                   {g.totalIssuedPoints !== undefined && (
                     <p className="text-xs text-gray-500 mt-1">
-                      政府発行済みポイント: {g.totalIssuedPoints} pt
+                      管理側発行済みポイント: {g.totalIssuedPoints} pt
                     </p>
                   )}
                 </Link>

--- a/app/(app)/quests/page.tsx
+++ b/app/(app)/quests/page.tsx
@@ -100,7 +100,7 @@ export default function AllQuestsPage() {
                   : "text-gray-600 border-gray-300 hover:border-blue-400"
               }`}
             >
-              {f === "ALL" ? "種別：すべて" : f === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+              {f === "ALL" ? "種別：すべて" : f === "GOVERNMENT" ? "管理側案件" : "メンバー案件"}
             </button>
           ))}
         </div>
@@ -133,7 +133,7 @@ export default function AllQuestsPage() {
                           {STATUS_LABEL[q.status]}
                         </span>
                         <span className="text-xs text-gray-400">
-                          {q.questType === "GOVERNMENT" ? "政府案件" : "メンバー案件"}
+                          {q.questType === "GOVERNMENT" ? "管理側案件" : "メンバー案件"}
                         </span>
                       </div>
                       <p className="text-sm font-medium text-gray-800 truncate">{q.title}</p>

--- a/app/InvitationList.tsx
+++ b/app/InvitationList.tsx
@@ -57,7 +57,7 @@ export default function InvitationList() {
               </p>
               <p className="text-xs text-gray-400 mt-0.5">
                 招待者: {inv.inviter.user.name ?? inv.inviter.user.email} ／
-                ロール: {inv.role === "LEADER" ? "政府関係者（LEADER）" : "一般メンバー"}
+                ロール: {inv.role === "LEADER" ? "管理側メンバー（LEADER）" : "一般メンバー"}
               </p>
             </div>
             <div className="flex gap-2 shrink-0">

--- a/app/api/groups/[id]/grant/route.ts
+++ b/app/api/groups/[id]/grant/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
 // ポイントを直接付与する（ADMINのみ）
-// 政府の未割当ポイント（発行済み - 流通中 - 政府案件の報酬合計）から充当する
+// 管理側の未割当ポイント（発行済み - 流通中 - 管理側案件の報酬合計）から充当する
 // body: { amount: number, memberId?: string }
 //   memberId あり → 個人付与
 //   memberId なし → グループ全員に付与（合計 = amount × 人数）

--- a/app/api/groups/[id]/invitations/route.ts
+++ b/app/api/groups/[id]/invitations/route.ts
@@ -35,7 +35,7 @@ export async function POST(
 
   // LEADERはMEMBERしか招待できない
   if (inviterMember.role === "LEADER" && role === "LEADER") {
-    return NextResponse.json({ error: "政府関係者の招待はADMINのみ実行できます" }, { status: 403 });
+    return NextResponse.json({ error: "管理側メンバーの招待はADMINのみ実行できます" }, { status: 403 });
   }
 
   // 招待対象ユーザーを検索

--- a/app/api/groups/[id]/members/[memberId]/route.ts
+++ b/app/api/groups/[id]/members/[memberId]/route.ts
@@ -40,7 +40,7 @@ export async function DELETE(
 
   // LEADERはADMIN・LEADERを削除不可
   if (operator.role === "LEADER" && target.role !== "MEMBER") {
-    return NextResponse.json({ error: "政府関係者・管理人の削除はADMINのみ実行できます" }, { status: 403 });
+    return NextResponse.json({ error: "管理側メンバー・管理人の削除はADMINのみ実行できます" }, { status: 403 });
   }
 
   // ADMINは削除不可（グループに必ず1人は必要）

--- a/app/api/groups/[id]/quest-proposals/[proposalId]/approve/route.ts
+++ b/app/api/groups/[id]/quest-proposals/[proposalId]/approve/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { addQuestLog } from "@/lib/questLog";
 
-// 提案を承認して政府案件として発行（ADMIN/LEADERのみ）
+// 提案を承認して管理側案件として発行（ADMIN/LEADERのみ）
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ id: string; proposalId: string }> }
@@ -35,7 +35,7 @@ export async function POST(
     return NextResponse.json({ error: "すでに審査済みの提案です" }, { status: 400 });
   }
 
-  // 政府の未割当ポイントを確認
+  // 管理側の未割当ポイントを確認
   const body = await req.json().catch(() => ({}));
   const pointReward: number = typeof body.pointReward === "number" ? body.pointReward : proposal.pointReward;
   const title: string = body.title?.trim() || proposal.title;
@@ -53,7 +53,7 @@ export async function POST(
 
   if (pointReward > available) {
     return NextResponse.json(
-      { error: `政府の未割当ポイントが不足しています（残り ${available} pt）` },
+      { error: `管理側の未割当ポイントが不足しています（残り ${available} pt）` },
       { status: 400 }
     );
   }

--- a/app/api/groups/[id]/quests/route.ts
+++ b/app/api/groups/[id]/quests/route.ts
@@ -28,7 +28,7 @@ export async function GET(
 }
 
 // クエスト作成
-// GOVERNMENT: ADMIN・LEADERのみ。政府の未割当ポイントから報酬を確保
+// GOVERNMENT: ADMIN・LEADERのみ。管理側の未割当ポイントから報酬を確保
 // MEMBER: 全員可。作成者の保有ポイントからエスクロー（即時引落）
 export async function POST(
   req: Request,
@@ -61,13 +61,13 @@ export async function POST(
   }
 
   if (questType === "GOVERNMENT") {
-    // 政府案件：ADMIN・LEADERのみ作成可
+    // 管理側案件：ADMIN・LEADERのみ作成可
     if (creatorMember.role === "MEMBER") {
-      return NextResponse.json({ error: "政府案件の発行はADMIN・LEADERのみ実行できます" }, { status: 403 });
+      return NextResponse.json({ error: "管理側案件の発行はADMIN・LEADERのみ実行できます" }, { status: 403 });
     }
 
-    // 政府の未割当ポイントを計算
-    // 未割当 = 発行済み - 流通中（memberPoints合計）- 既存のオープン政府案件の報酬合計（escrow）
+    // 管理側の未割当ポイントを計算
+    // 未割当 = 発行済み - 流通中（memberPoints合計）- 既存のオープン管理側案件の報酬合計（escrow）
     const group = await prisma.group.findUnique({ where: { id: groupId } });
     const members = await prisma.groupMember.findMany({ where: { groupId } });
     const totalCirculating = members.reduce((sum, m) => sum + m.memberPoints, 0);
@@ -79,7 +79,7 @@ export async function POST(
 
     if (pointReward > available) {
       return NextResponse.json(
-        { error: `政府の未割当ポイントが不足しています（残り ${available} pt）` },
+        { error: `管理側の未割当ポイントが不足しています（残り ${available} pt）` },
         { status: 400 }
       );
     }

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
-// 政府発行済みポイントを加減算（ADMINのみ）
+// 管理側発行済みポイントを加減算（ADMINのみ）
 // delta > 0: 追加発行
 // delta < 0: 回収（流通中のポイントは回収不可）
 export async function PATCH(


### PR DESCRIPTION
## Summary
- UI・APIエラーメッセージ・コメント全体で「政府」→「管理側」に変更
- 主な変更: 政府案件→管理側案件、政府関係者→管理側メンバー、政府発行済みポイント→管理側発行済みポイント
- Prismaスキーマのenum値（GOVERNMENT等）は変更なし

## Test plan
- [ ] クエスト一覧で「管理側案件」と表示される
- [ ] グループページでロール「管理側メンバー」と表示される
- [ ] ポイント管理画面で「管理側発行済みポイント」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)