### PR TITLE
feat: ポイント付与で複数人選択に対応

### DIFF
--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -771,13 +771,20 @@ function GrantPointsSection({
   onGranted: (memberId: string | null, amount: number) => void;
   group: Pick<Group, "pointUnit" | "laborCostPerHour" | "timeUnit">;
 }) {
-  const [mode, setMode] = useState<"individual" | "all">("individual");
+  const [mode, setMode] = useState<"individual" | "multiple" | "all">("individual");
   const [selectedMemberId, setSelectedMemberId] = useState(members[0]?.id ?? "");
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
   const [amount, setAmount] = useState(0);
   const [selectedInputUnit, setSelectedInputUnit] = useState(group.timeUnit);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+
+  function toggleMemberId(id: string) {
+    setSelectedMemberIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  }
 
   // 入力単位の切り替えが可能か（円表示 & 人件費設定済みの場合）
   const canSelectUnit = group.pointUnit === "円" && group.laborCostPerHour > 0;
@@ -795,8 +802,9 @@ function GrantPointsSection({
     const ptAmount = unitToPt(amount, inputGroup);
     setSubmitting(true);
     try {
-      const body: { amount: number; memberId?: string } = { amount: ptAmount };
+      const body: { amount: number; memberId?: string; memberIds?: string[] } = { amount: ptAmount };
       if (mode === "individual") body.memberId = selectedMemberId;
+      if (mode === "multiple") body.memberIds = selectedMemberIds;
       const res = await fetch(`/api/groups/${groupId}/grant`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -810,6 +818,10 @@ function GrantPointsSection({
       if (mode === "individual") {
         onGranted(selectedMemberId, ptAmount);
         setSuccess(`${amount} ${unitLabel} を付与しました`);
+      } else if (mode === "multiple") {
+        onGranted(null, ptAmount);
+        setSuccess(`${data.memberCount}人に ${amount} ${unitLabel} を付与しました（合計 ${data.totalGranted} pt）`);
+        setSelectedMemberIds([]);
       } else {
         onGranted(null, ptAmount);
         setSuccess(`全員に ${amount} ${unitLabel} を付与しました（合計 ${data.totalGranted} pt）`);
@@ -826,22 +838,37 @@ function GrantPointsSection({
 
       <div className="flex gap-4">
         <label className="flex items-center gap-2 cursor-pointer text-sm">
-          <input
-            type="radio"
-            checked={mode === "individual"}
-            onChange={() => setMode("individual")}
-          />
+          <input type="radio" checked={mode === "individual"} onChange={() => setMode("individual")} />
           個人に付与
         </label>
         <label className="flex items-center gap-2 cursor-pointer text-sm">
-          <input
-            type="radio"
-            checked={mode === "all"}
-            onChange={() => setMode("all")}
-          />
+          <input type="radio" checked={mode === "multiple"} onChange={() => { setMode("multiple"); setSelectedMemberIds([]); }} />
+          複数人に付与
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer text-sm">
+          <input type="radio" checked={mode === "all"} onChange={() => setMode("all")} />
           全員に付与
         </label>
       </div>
+
+      {mode === "multiple" && (
+        <div className="flex flex-wrap gap-2">
+          {members.map((m) => (
+            <label key={m.id} className="flex items-center gap-1.5 cursor-pointer text-sm border border-gray-200 rounded-lg px-3 py-1.5 hover:border-blue-400 transition">
+              <input
+                type="checkbox"
+                checked={selectedMemberIds.includes(m.id)}
+                onChange={() => toggleMemberId(m.id)}
+                className="rounded"
+              />
+              {m.user.name ?? m.user.email}
+            </label>
+          ))}
+          {selectedMemberIds.length > 0 && (
+            <span className="text-xs text-gray-400 self-center">{selectedMemberIds.length}人選択中</span>
+          )}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="flex flex-wrap gap-3 items-end">
         {mode === "individual" && (

--- a/app/api/groups/[id]/grant/route.ts
+++ b/app/api/groups/[id]/grant/route.ts
@@ -4,9 +4,10 @@ import { prisma } from "@/lib/prisma";
 
 // ポイントを直接付与する（ADMINのみ）
 // 管理側の未割当ポイント（発行済み - 流通中 - 管理側案件の報酬合計）から充当する
-// body: { amount: number, memberId?: string }
+// body: { amount: number, memberId?: string, memberIds?: string[] }
 //   memberId あり → 個人付与
-//   memberId なし → グループ全員に付与（合計 = amount × 人数）
+//   memberIds あり → 複数人付与（合計 = amount × 人数）
+//   どちらもなし → グループ全員に付与（合計 = amount × 人数）
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -17,7 +18,7 @@ export async function POST(
   }
 
   const { id: groupId } = await params;
-  const { amount, memberId } = await req.json();
+  const { amount, memberId, memberIds } = await req.json();
 
   if (typeof amount !== "number" || !Number.isInteger(amount) || amount <= 0) {
     return NextResponse.json({ error: "付与量は1以上の整数で指定してください" }, { status: 400 });
@@ -61,9 +62,26 @@ export async function POST(
       include: { user: { select: { id: true, name: true, email: true } } },
     });
     return NextResponse.json({ type: "individual", updated });
+  } else if (Array.isArray(memberIds) && memberIds.length > 0) {
+    // ── 複数人付与 ──────────────────────────────────────────
+    const validIds = memberIds.filter((id) => allMembers.some((m) => m.id === id));
+    if (validIds.length === 0) {
+      return NextResponse.json({ error: "有効なメンバーが選択されていません" }, { status: 400 });
+    }
+    const totalCost = amount * validIds.length;
+    if (totalCost > available) {
+      return NextResponse.json(
+        { error: `未割当ポイントが不足しています（必要: ${totalCost} pt、残り: ${available} pt）` },
+        { status: 400 }
+      );
+    }
+    await prisma.groupMember.updateMany({
+      where: { id: { in: validIds } },
+      data: { memberPoints: { increment: amount } },
+    });
+    return NextResponse.json({ type: "multiple", totalGranted: totalCost, memberCount: validIds.length });
   } else {
     // ── 全員付与 ──────────────────────────────────────────
-    const targets = allMembers.filter((m) => m.id !== operator.id); // ADMIN自身は除外するか含めるか？→含める
     const totalCost = amount * allMembers.length;
     if (totalCost > available) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- ポイント付与に「複数人に付与」モードを追加
- チェックボックスで対象メンバーを複数選択可能
- 選択人数をリアルタイム表示
- モード: 個人 / 複数人 / 全員（全員はこれまで通り）

## Test plan
- [ ] 「複数人に付与」を選択するとチェックボックスが表示される
- [ ] チェックしたメンバーのみにポイントが付与される
- [ ] 未割当ポイント不足時はエラーが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)