### PR TITLE
feat: グループの発行単位をクエスト一覧・詳細にも反映

### DIFF
--- a/app/(app)/groups/[id]/quests/[questId]/page.tsx
+++ b/app/(app)/groups/[id]/quests/[questId]/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { formatPoint, unitLabel, type PointGroup } from "@/lib/pointFormat";
+
+const DEFAULT_POINT_GROUP: PointGroup = { pointUnit: "pt", laborCostPerHour: 0, timeUnit: "HOUR" };
 
 type QuestUser = { id: string; name: string | null; email: string };
 type QuestMember = { id: string; user: QuestUser };
@@ -80,6 +83,7 @@ export default function QuestDetailPage() {
   const [quest, setQuest] = useState<Quest | null>(null);
   const [members, setMembers] = useState<GroupMember[]>([]);
   const [myMember, setMyMember] = useState<GroupMember | null>(null);
+  const [pointGroup, setPointGroup] = useState<PointGroup>(DEFAULT_POINT_GROUP);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [completing, setCompleting] = useState(false);
@@ -107,8 +111,9 @@ export default function QuestDetailPage() {
       .then(([questData, me, groups, proposals]) => {
         setQuest(questData);
         if (me?.id && Array.isArray(groups)) {
-          const group = groups.find((g: { id: string; members: GroupMember[] }) => g.id === groupId);
+          const group = groups.find((g: { id: string; members: GroupMember[]; pointUnit: string; laborCostPerHour: number; timeUnit: string }) => g.id === groupId);
           setMembers(group?.members ?? []);
+          if (group) setPointGroup({ pointUnit: group.pointUnit, laborCostPerHour: group.laborCostPerHour, timeUnit: group.timeUnit });
           const m = group?.members.find((m: GroupMember) => m.user.id === me.id);
           if (m) setMyMember(m);
         }
@@ -249,13 +254,13 @@ export default function QuestDetailPage() {
         <div className="flex items-center gap-4 py-3 border-t border-gray-100">
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-500">報酬</span>
-            <span className="text-2xl font-bold text-blue-600">{quest.pointReward} pt</span>
+            <span className="text-2xl font-bold text-blue-600">{formatPoint(quest.pointReward, pointGroup)}</span>
           </div>
           {quest.status === "COMPLETED" && quest.actualPaidPoints !== null && (
             <div className="flex items-center gap-1.5">
               <span className="text-sm text-gray-400">実際の支払</span>
               <span className={`text-lg font-bold ${quest.actualPaidPoints > quest.pointReward ? "text-green-600" : quest.actualPaidPoints < quest.pointReward ? "text-red-500" : "text-blue-600"}`}>
-                {quest.actualPaidPoints} pt
+                {formatPoint(quest.actualPaidPoints, pointGroup)}
               </span>
             </div>
           )}
@@ -365,10 +370,10 @@ export default function QuestDetailPage() {
             <span className="text-xs text-gray-500">
               報酬合計:{" "}
               <span className="font-bold text-blue-600">
-                {quest.subQuests.reduce((s, sq) => s + sq.pointReward, 0)} pt
+                {formatPoint(quest.subQuests.reduce((s, sq) => s + sq.pointReward, 0), pointGroup)}
               </span>
               {" / "}
-              {quest.pointReward} pt
+              {formatPoint(quest.pointReward, pointGroup)}
             </span>
           )}
         </div>
@@ -401,7 +406,7 @@ export default function QuestDetailPage() {
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       {sq.pointReward > 0 && (
-                        <span className="text-sm font-bold text-blue-600">{sq.pointReward} pt</span>
+                        <span className="text-sm font-bold text-blue-600">{formatPoint(sq.pointReward, pointGroup)}</span>
                       )}
                       <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${SUB_STATUS_COLOR[sq.status]}`}>
                         {SUB_STATUS_LABEL[sq.status]}
@@ -422,6 +427,7 @@ export default function QuestDetailPage() {
             myMemberId={myMember?.id ?? ""}
             questPointReward={quest.pointReward}
             usedPointReward={quest.subQuests.reduce((s, sq) => s + sq.pointReward, 0)}
+            pointGroup={pointGroup}
             onAdded={(sq) => setQuest((prev) => prev ? { ...prev, subQuests: [...prev.subQuests, sq] } : prev)}
           />
         )}
@@ -579,6 +585,7 @@ function AddSubQuestForm({
   myMemberId,
   questPointReward,
   usedPointReward,
+  pointGroup,
   onAdded,
 }: {
   groupId: string;
@@ -587,6 +594,7 @@ function AddSubQuestForm({
   myMemberId: string;
   questPointReward: number;
   usedPointReward: number;
+  pointGroup: PointGroup;
   onAdded: (sq: SubQuest) => void;
 }) {
   const [title, setTitle] = useState("");
@@ -607,7 +615,7 @@ function AddSubQuestForm({
     e.preventDefault();
     setError("");
     if (resolvedPt > remaining) {
-      setError(`報酬が残り上限（${remaining} pt）を超えています`);
+      setError(`報酬が残り上限（${formatPoint(remaining, pointGroup)}）を超えています`);
       return;
     }
     setSubmitting(true);
@@ -667,7 +675,7 @@ function AddSubQuestForm({
       <div>
         <div className="flex items-center justify-between mb-1">
           <label className="text-xs text-gray-500">
-            報酬（残り {remaining} pt）
+            報酬（残り {formatPoint(remaining, pointGroup)}）
           </label>
           <div className="flex gap-2">
             {(["pt", "percent"] as const).map((m) => (
@@ -677,7 +685,7 @@ function AddSubQuestForm({
                   checked={rewardMode === m}
                   onChange={() => { setRewardMode(m); setPointReward(0); setPercent(0); }}
                 />
-                {m === "pt" ? "pt" : "%"}
+                {m === "pt" ? unitLabel(pointGroup) : "%"}
               </label>
             ))}
           </div>
@@ -702,7 +710,7 @@ function AddSubQuestForm({
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
             />
             <span className="text-sm text-gray-500 shrink-0">%</span>
-            <span className="text-xs text-gray-400 shrink-0">= {ptFromPercent} pt</span>
+            <span className="text-xs text-gray-400 shrink-0">= {formatPoint(ptFromPercent, pointGroup)}</span>
           </div>
         )}
       </div>
@@ -838,7 +846,7 @@ function EditQuestForm({
         />
       </div>
       <div>
-        <label className="block text-xs text-gray-500 mb-1">報酬（pt）</label>
+        <label className="block text-xs text-gray-500 mb-1">報酬</label>
         <input
           type="number"
           value={pointReward}

--- a/app/(app)/groups/[id]/quests/page.tsx
+++ b/app/(app)/groups/[id]/quests/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { formatPoint, unitLabel, type PointGroup } from "@/lib/pointFormat";
 
 type Role = "ADMIN" | "LEADER" | "MEMBER";
 
@@ -43,12 +44,16 @@ const STATUS_COLOR: Record<Quest["status"], string> = {
   CANCELLED: "bg-red-100 text-red-500",
 };
 
+const DEFAULT_POINT_GROUP: PointGroup = { pointUnit: "pt", laborCostPerHour: 0, timeUnit: "HOUR" };
+
 export default function QuestsPage() {
   const { id: groupId } = useParams<{ id: string }>();
   const [quests, setQuests] = useState<Quest[]>([]);
   const [myMember, setMyMember] = useState<GroupMember | null>(null);
-  const [tab, setTab] = useState<"GOVERNMENT" | "MEMBER">("GOVERNMENT");
+  const [pointGroup, setPointGroup] = useState<PointGroup>(DEFAULT_POINT_GROUP);
   const [showForm, setShowForm] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<"ALL" | Quest["status"]>("IN_PROGRESS");
+  const [typeFilter, setTypeFilter] = useState<"ALL" | "GOVERNMENT" | "MEMBER">("ALL");
 
   useEffect(() => {
     Promise.all([
@@ -58,16 +63,17 @@ export default function QuestsPage() {
     ]).then(([questData, me, groups]) => {
       if (Array.isArray(questData)) setQuests(questData);
       if (me?.id && Array.isArray(groups)) {
-        const group = groups.find((g: { id: string; members: GroupMember[] }) => g.id === groupId);
-        const member = group?.members.find((m: GroupMember) => m.user.id === me.id);
-        if (member) setMyMember(member);
+        const group = groups.find((g: { id: string; members: GroupMember[]; pointUnit: string; laborCostPerHour: number; timeUnit: string }) => g.id === groupId);
+        if (group) {
+          setPointGroup({ pointUnit: group.pointUnit, laborCostPerHour: group.laborCostPerHour, timeUnit: group.timeUnit });
+          const member = group.members.find((m: GroupMember) => m.user.id === me.id);
+          if (member) setMyMember(member);
+        }
       }
     });
   }, [groupId]);
 
   const canCreateGov = myMember?.role === "ADMIN" || myMember?.role === "LEADER";
-  const [statusFilter, setStatusFilter] = useState<"ALL" | Quest["status"]>("IN_PROGRESS");
-  const [typeFilter, setTypeFilter] = useState<"ALL" | "GOVERNMENT" | "MEMBER">("ALL");
 
   const filtered = quests.filter(
     (q) =>
@@ -122,7 +128,7 @@ export default function QuestsPage() {
         {/* 保有ポイント表示 */}
         {myMember && (
           <p className="text-sm text-gray-500">
-            あなたの保有ポイント: <strong className="text-gray-800">{myMember.memberPoints} pt</strong>
+            あなたの保有ポイント: <strong className="text-gray-800">{formatPoint(myMember.memberPoints, pointGroup)}</strong>
           </p>
         )}
 
@@ -132,6 +138,7 @@ export default function QuestsPage() {
             groupId={groupId}
             canCreateGov={canCreateGov}
             myPoints={myMember.memberPoints}
+            pointGroup={pointGroup}
             onCreated={(q) => {
               setQuests((prev) => [q, ...prev]);
               setShowForm(false);
@@ -149,7 +156,7 @@ export default function QuestsPage() {
           <p className="text-gray-400 text-sm py-8 text-center">該当するクエストがありません</p>
         ) : (
           <ul className="space-y-2">
-            {filtered.map((q) => <QuestCard key={q.id} quest={q} groupId={groupId} />)}
+            {filtered.map((q) => <QuestCard key={q.id} quest={q} groupId={groupId} pointGroup={pointGroup} />)}
           </ul>
         )}
       </main>
@@ -157,7 +164,7 @@ export default function QuestsPage() {
   );
 }
 
-function QuestCard({ quest, groupId }: { quest: Quest; groupId: string }) {
+function QuestCard({ quest, groupId, pointGroup }: { quest: Quest; groupId: string; pointGroup: PointGroup }) {
   const isOverdue = quest.deadline && quest.status !== "COMPLETED" && quest.status !== "CANCELLED"
     && new Date(quest.deadline) < new Date();
 
@@ -184,7 +191,7 @@ function QuestCard({ quest, groupId }: { quest: Quest; groupId: string }) {
           </div>
           <p className="text-sm font-medium text-gray-800 truncate">{quest.title}</p>
         </div>
-        <p className="text-base font-bold text-blue-600 shrink-0">{quest.pointReward} pt</p>
+        <p className="text-base font-bold text-blue-600 shrink-0">{formatPoint(quest.pointReward, pointGroup)}</p>
       </Link>
     </li>
   );
@@ -194,12 +201,14 @@ function CreateQuestForm({
   groupId,
   canCreateGov,
   myPoints,
+  pointGroup,
   onCreated,
   onCancel,
 }: {
   groupId: string;
   canCreateGov: boolean;
   myPoints: number;
+  pointGroup: PointGroup;
   onCreated: (q: Quest) => void;
   onCancel: () => void;
 }) {
@@ -212,6 +221,8 @@ function CreateQuestForm({
   const [deadline, setDeadline] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+
+  const label = unitLabel(pointGroup);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -264,7 +275,7 @@ function CreateQuestForm({
 
       {questType === "MEMBER" && (
         <p className="text-xs text-gray-400">
-          ※ 報酬は作成時にあなたの保有ポイント（{myPoints} pt）から引き落とされます
+          ※ 報酬は作成時にあなたの保有ポイント（{formatPoint(myPoints, pointGroup)}）から引き落とされます
         </p>
       )}
 
@@ -295,7 +306,7 @@ function CreateQuestForm({
             className="w-32 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
             required
           />
-          <span className="text-sm text-gray-500">pt</span>
+          <span className="text-sm text-gray-500">{label}</span>
         </div>
         <div>
           <label className="block text-xs text-gray-500 mb-1">デッドライン（任意）</label>

--- a/lib/pointFormat.ts
+++ b/lib/pointFormat.ts
@@ -1,0 +1,38 @@
+export type PointGroup = {
+  pointUnit: string;
+  laborCostPerHour: number;
+  timeUnit: string;
+};
+
+export const TIME_UNIT_LABEL: Record<string, string> = {
+  YEN: "円",
+  HOUR: "人・時間",
+  DAY: "人・日",
+  WEEK: "人・週",
+  MONTH: "人・月",
+};
+
+const TIME_UNIT_MULTIPLIER: Record<string, number> = {
+  HOUR: 1,
+  DAY: 1 / 8,
+  WEEK: 1 / (8 * 5),
+  MONTH: 1 / (8 * 5 * 4),
+};
+
+export function formatPoint(points: number, group: PointGroup): string {
+  if (group.pointUnit === "円") {
+    if (group.timeUnit === "YEN" || !group.laborCostPerHour) {
+      return `${points.toLocaleString("ja-JP")} 円`;
+    }
+    const personHours = points / group.laborCostPerHour;
+    const value = personHours * (TIME_UNIT_MULTIPLIER[group.timeUnit] ?? 1);
+    return `${value.toLocaleString("ja-JP")} ${TIME_UNIT_LABEL[group.timeUnit]}`;
+  }
+  return `${points} pt`;
+}
+
+export function unitLabel(group: PointGroup): string {
+  if (group.pointUnit !== "円") return "pt";
+  if (group.timeUnit === "YEN" || !group.laborCostPerHour) return "円";
+  return TIME_UNIT_LABEL[group.timeUnit] ?? "円";
+}


### PR DESCRIPTION
## Summary
- `lib/pointFormat.ts` に共通ユーティリティ `formatPoint` / `unitLabel` を切り出し
- クエスト一覧ページ: 報酬・保有ポイント・発行フォームの単位をグループ設定に合わせて表示
- クエスト詳細ページ: 報酬・実際の支払・サブクエスト報酬・残り上限すべてをグループ設定で表示
- 単位が「pt」の場合は従来通り `N pt` で表示

## Test plan
- [ ] pointUnit=pt のグループでは従来通り `N pt` と表示される
- [ ] pointUnit=円 timeUnit=YEN のグループでは `N 円` と表示される
- [ ] pointUnit=円 laborCostPerHour設定済み timeUnit=HOUR では `N 人・時間` と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)