### PR TITLE
feat: ポイント表示に3桁カンマ区切りを追加

### DIFF
--- a/app/(app)/groups/[id]/members/page.tsx
+++ b/app/(app)/groups/[id]/members/page.tsx
@@ -35,7 +35,7 @@ function formatPoint(points: number, group: Pick<Group, "pointUnit" | "laborCost
     const value = (points / group.laborCostPerHour) * (TIME_UNIT_MULTIPLIER[group.timeUnit] ?? 1);
     return `${value.toLocaleString("ja-JP")} ${TIME_UNIT_LABEL[group.timeUnit]}`;
   }
-  return `${points} pt`;
+  return `${points.toLocaleString("ja-JP")} pt`;
 }
 
 const ROLE_LABEL: Record<Role, string> = {

--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -70,7 +70,7 @@ function formatPoint(points: number, group: Pick<Group, "pointUnit" | "laborCost
     const value = personHours * (TIME_UNIT_MULTIPLIER[group.timeUnit] ?? 1);
     return `${value.toLocaleString("ja-JP")} ${TIME_UNIT_LABEL[group.timeUnit]}`;
   }
-  return `${displayed} pt`;
+  return `${displayed.toLocaleString("ja-JP")} pt`;
 }
 
 type Quest = {

--- a/lib/pointFormat.ts
+++ b/lib/pointFormat.ts
@@ -31,7 +31,7 @@ export function formatPoint(points: number, group: PointGroup): string {
     const value = personHours * (TIME_UNIT_MULTIPLIER[group.timeUnit] ?? 1);
     return `${value.toLocaleString("ja-JP")} ${TIME_UNIT_LABEL[group.timeUnit]}`;
   }
-  return `${displayed} pt`;
+  return `${displayed.toLocaleString("ja-JP")} pt`;
 }
 
 export function unitLabel(group: PointGroup): string {


### PR DESCRIPTION
## 概要

ptポイントの表示に3桁カンマ区切り（`toLocaleString("ja-JP")`）を追加しました。

## 変更内容

- `lib/pointFormat.ts`: pt単位の返り値をカンマ区切りに変更
- `app/(app)/groups/[id]/page.tsx`: ローカルの `formatPoint` も同様に変更
- `app/(app)/groups/[id]/members/page.tsx`: メンバーページの `formatPoint` も同様に変更

Closes #