### PR TITLE
feat: 全体UIを大幅リデザイン

### DIFF
--- a/app/(app)/contact/page.tsx
+++ b/app/(app)/contact/page.tsx
@@ -31,40 +31,50 @@ export default function ContactPage() {
   }
 
   return (
-    <main className="max-w-2xl mx-auto px-6 py-10 space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold text-gray-800">開発者へのお問い合わせ</h2>
-        <p className="text-sm text-gray-500 mt-1">ご意見・ご要望・バグ報告などをお送りください。</p>
+    <main className="max-w-2xl mx-auto px-6 py-10 space-y-6">
+      {/* ページヘッダー */}
+      <div className="relative bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 rounded-2xl p-6 shadow-xl overflow-hidden">
+        <div className="absolute top-0 right-0 w-40 h-40 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/4 pointer-events-none" />
+        <div className="relative">
+          <h2 className="text-2xl font-bold text-white">開発者へのお問い合わせ</h2>
+          <p className="text-indigo-200 text-sm mt-1">ご意見・ご要望・バグ報告などをお送りください。</p>
+        </div>
       </div>
 
       {/* SNSリンク */}
-      <div className="bg-white border border-gray-200 rounded-xl px-6 py-4 flex items-center gap-4">
+      <div className="bg-white border border-slate-100 rounded-2xl px-6 py-5 flex items-center gap-4 shadow-sm hover:shadow-md transition">
+        <div className="w-10 h-10 rounded-xl bg-black flex items-center justify-center shrink-0">
+          <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.747l7.73-8.835L1.254 2.25H8.08l4.261 5.635 5.903-5.635zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
+          </svg>
+        </div>
         <div>
-          <p className="text-sm font-medium text-gray-700">開発者 SNS</p>
-          <p className="text-xs text-gray-400 mt-0.5">気軽にDMもどうぞ</p>
+          <p className="text-sm font-semibold text-slate-700">開発者 SNS</p>
+          <p className="text-xs text-slate-400 mt-0.5">気軽にDMもどうぞ</p>
         </div>
         <a
           href="https://x.com/takeshi_program"
           target="_blank"
           rel="noopener noreferrer"
-          className="ml-auto flex items-center gap-2 px-4 py-2 bg-black text-white text-sm rounded-lg hover:bg-gray-800 transition"
+          className="ml-auto flex items-center gap-2 px-4 py-2 bg-black text-white text-sm rounded-xl hover:bg-slate-800 transition shadow"
         >
-          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.747l7.73-8.835L1.254 2.25H8.08l4.261 5.635 5.903-5.635zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
-          </svg>
           @takeshi_program
         </a>
       </div>
 
       {/* お問い合わせフォーム */}
-      <div className="bg-white border border-gray-200 rounded-xl p-6">
-        <p className="text-sm font-medium text-gray-700 mb-4">フォームで送る</p>
+      <div className="bg-white border border-slate-100 rounded-2xl p-6 shadow-sm">
+        <p className="text-sm font-bold text-slate-700 mb-5 flex items-center gap-2">
+          <span className="w-1.5 h-5 bg-gradient-to-b from-indigo-500 to-violet-600 rounded-full inline-block" />
+          フォームで送る
+        </p>
         {success ? (
-          <div className="text-center py-8 space-y-3">
-            <p className="text-green-600 font-medium">送信しました。ありがとうございます！</p>
+          <div className="text-center py-10 space-y-3">
+            <div className="text-5xl mb-2">✅</div>
+            <p className="text-green-600 font-semibold text-lg">送信しました。ありがとうございます！</p>
             <button
               onClick={() => setSuccess(false)}
-              className="text-sm text-blue-600 hover:text-blue-800 transition"
+              className="text-sm text-indigo-600 hover:text-indigo-800 transition"
             >
               続けて送る
             </button>
@@ -72,32 +82,36 @@ export default function ContactPage() {
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">タイトル</label>
+              <label className="block text-xs font-semibold text-slate-500 mb-1.5">タイトル</label>
               <input
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="例：○○機能のバグについて"
-                className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                className="w-full border border-slate-200 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-slate-50"
                 required
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">メッセージ</label>
+              <label className="block text-xs font-semibold text-slate-500 mb-1.5">メッセージ</label>
               <textarea
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 placeholder="詳細をご記入ください"
                 rows={6}
-                className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 resize-none"
+                className="w-full border border-slate-200 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 resize-none bg-slate-50"
                 required
               />
             </div>
-            {error && <p className="text-sm text-red-600">{error}</p>}
+            {error && (
+              <div className="px-4 py-2.5 bg-red-50 border border-red-100 rounded-xl">
+                <p className="text-sm text-red-600">{error}</p>
+              </div>
+            )}
             <button
               type="submit"
               disabled={submitting}
-              className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+              className="px-6 py-2.5 bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-sm font-semibold rounded-xl disabled:opacity-50 transition shadow-lg shadow-indigo-200"
             >
               {submitting ? "送信中..." : "送信する"}
             </button>

--- a/app/(app)/groups/[id]/page.tsx
+++ b/app/(app)/groups/[id]/page.tsx
@@ -161,7 +161,14 @@ export default function GroupDetailPage() {
     }).catch((e) => console.error("データの取得に失敗しました", e));
   }, [id]);
 
-  if (!group) return <div className="p-10 text-gray-500">読み込み中...</div>;
+  if (!group) return (
+    <div className="flex items-center justify-center p-20">
+      <div className="flex flex-col items-center gap-3 text-slate-400">
+        <div className="w-8 h-8 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin" />
+        <p className="text-sm">読み込み中...</p>
+      </div>
+    </div>
+  );
 
   const myMember = group.members.find((m) => m.user.id === myUserId);
   const myRole = myMember?.role ?? "MEMBER";
@@ -189,19 +196,27 @@ export default function GroupDetailPage() {
 
   return (
     <div>
-      <main className="max-w-4xl mx-auto px-6 py-10 space-y-8">
-        <section>
-          <div className="flex items-center gap-3 flex-wrap">
-            <h2 className="text-2xl font-bold text-gray-800">{group.name}</h2>
-            {myRole !== "MEMBER" && (
-              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${ROLE_BADGE[myRole]}`}>
-                {ROLE_LABEL[myRole]}
-              </span>
-            )}
+      <main className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        {/* グループヘッダー */}
+        <section className="relative bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 rounded-2xl p-6 shadow-xl overflow-hidden">
+          <div className="absolute top-0 right-0 w-48 h-48 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/4 pointer-events-none" />
+          <div className="absolute bottom-0 left-0 w-32 h-32 bg-white/5 rounded-full translate-y-1/2 -translate-x-1/4 pointer-events-none" />
+          <div className="relative flex items-center gap-3 flex-wrap">
+            <div>
+              <h2 className="text-2xl font-bold text-white">{group.name}</h2>
+              {myRole !== "MEMBER" && (
+                <span className="inline-block mt-1 text-xs px-2.5 py-0.5 rounded-full font-medium bg-white/20 text-white border border-white/20">
+                  {ROLE_LABEL[myRole]}
+                </span>
+              )}
+            </div>
             <Link
               href={`/groups/${id}/analytics`}
-              className="text-sm px-5 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+              className="ml-auto text-sm px-5 py-2 bg-white/15 hover:bg-white/25 text-white rounded-lg border border-white/20 transition flex items-center gap-2"
             >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
               分析
             </Link>
           </div>
@@ -223,11 +238,14 @@ export default function GroupDetailPage() {
         {/* 自分の情報 ＋ クエスト提案 2列 */}
         {myMember && (
         <div className="grid grid-cols-2 gap-4 items-start">
-          <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-4">
-            <h3 className="font-semibold text-gray-800">自分の情報</h3>
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-gray-500">保有ポイント</span>
-              <span className="text-3xl font-bold text-blue-600">{formatPoint(myMember.memberPoints, group)}</span>
+          <section className="bg-white border border-slate-100 rounded-2xl p-6 space-y-4 shadow-sm hover:shadow-md transition">
+            <h3 className="font-bold text-slate-700 flex items-center gap-2">
+              <span className="w-1.5 h-5 bg-gradient-to-b from-indigo-500 to-violet-600 rounded-full inline-block" />
+              自分の情報
+            </h3>
+            <div className="bg-gradient-to-br from-indigo-50 to-violet-50 rounded-xl p-4 border border-indigo-100">
+              <p className="text-xs font-medium text-slate-500 mb-1">保有ポイント</p>
+              <span className="text-3xl font-bold bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">{formatPoint(myMember.memberPoints, group)}</span>
             </div>
 
             <div className="border-t border-gray-100 pt-4">
@@ -298,30 +316,32 @@ export default function GroupDetailPage() {
             </div>
           </section>
 
-          <div className="space-y-4">
+          <div className="space-y-3">
             <Link
               href={`/groups/${id}/quest-proposals`}
-              className="block bg-white border border-gray-200 rounded-xl px-6 py-4 hover:shadow-md transition"
+              className="flex items-center gap-4 bg-white border border-slate-100 rounded-2xl px-5 py-4 hover:shadow-md hover:-translate-y-0.5 transition-all shadow-sm"
             >
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-semibold text-gray-800">管理者へのクエスト提案</p>
-                  <p className="text-xs text-gray-400 mt-0.5">メンバーからの提案一覧・審査承認</p>
-                </div>
-                <span className="text-gray-400">→</span>
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center text-white text-lg shadow shrink-0">
+                💡
               </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold text-slate-800 text-sm">管理者へのクエスト提案</p>
+                <p className="text-xs text-slate-400 mt-0.5">メンバーからの提案一覧・審査承認</p>
+              </div>
+              <span className="text-slate-300 text-lg">→</span>
             </Link>
             <Link
               href={`/groups/${id}/quests`}
-              className="block bg-white border border-gray-200 rounded-xl px-6 py-4 hover:shadow-md transition"
+              className="flex items-center gap-4 bg-white border border-slate-100 rounded-2xl px-5 py-4 hover:shadow-md hover:-translate-y-0.5 transition-all shadow-sm"
             >
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="font-semibold text-gray-800">クエスト</p>
-                  <p className="text-xs text-gray-400 mt-0.5">管理側案件・メンバー案件の一覧と発行</p>
-                </div>
-                <span className="text-gray-400">→</span>
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center text-white text-lg shadow shrink-0">
+                ⚔️
               </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-semibold text-slate-800 text-sm">クエスト</p>
+                <p className="text-xs text-slate-400 mt-0.5">管理側案件・メンバー案件の一覧と発行</p>
+              </div>
+              <span className="text-slate-300 text-lg">→</span>
             </Link>
           </div>
         </div>
@@ -362,15 +382,16 @@ export default function GroupDetailPage() {
         {/* メンバー管理ページへのリンク */}
         <Link
           href={`/groups/${id}/members`}
-          className="block bg-white border border-gray-200 rounded-xl px-6 py-4 hover:shadow-md transition"
+          className="flex items-center gap-4 bg-white border border-slate-100 rounded-2xl px-6 py-5 hover:shadow-md hover:-translate-y-0.5 transition-all shadow-sm"
         >
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="font-semibold text-gray-800">メンバー</p>
-              <p className="text-xs text-gray-400 mt-0.5">メンバー一覧・招待・管理</p>
-            </div>
-            <span className="text-gray-400">→</span>
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center text-white text-lg shadow shrink-0">
+            👥
           </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-slate-800">メンバー</p>
+            <p className="text-xs text-slate-400 mt-0.5">メンバー一覧・招待・管理</p>
+          </div>
+          <span className="text-slate-300 text-lg">→</span>
         </Link>
       </main>
     </div>
@@ -445,16 +466,19 @@ function IssuedPointsEditor({
   }
 
   return (
-    <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-5">
+    <section className="bg-white border border-slate-100 rounded-2xl p-6 space-y-5 shadow-sm">
       <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-gray-800">管理側発行済みポイント</h3>
+        <h3 className="font-bold text-slate-700 flex items-center gap-2">
+          <span className="w-1.5 h-5 bg-gradient-to-b from-indigo-500 to-violet-600 rounded-full inline-block" />
+          管理側発行済みポイント
+        </h3>
         {isAdmin && (
           <button
             onClick={() => setSettingsOpen((v) => !v)}
-            className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-800 transition"
+            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-700 transition"
           >
             表示設定
-            <span className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${settingsOpen ? "bg-blue-600" : "bg-gray-300"}`}>
+            <span className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${settingsOpen ? "bg-indigo-500" : "bg-slate-200"}`}>
               <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${settingsOpen ? "translate-x-4" : "translate-x-0.5"}`} />
             </span>
           </button>
@@ -463,8 +487,8 @@ function IssuedPointsEditor({
 
       {/* 表示設定パネル */}
       {settingsOpen && (
-        <form onSubmit={saveSettings} className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3">
-          <p className="text-xs font-medium text-gray-600">表示・人件費設定</p>
+        <form onSubmit={saveSettings} className="bg-gradient-to-br from-slate-50 to-indigo-50 border border-indigo-100 rounded-xl p-4 space-y-3">
+          <p className="text-xs font-bold text-slate-600">表示・人件費設定</p>
           <div className="flex flex-wrap gap-4 items-end">
             <div>
               <p className="text-xs text-gray-500 mb-1">表示単位</p>
@@ -519,14 +543,14 @@ function IssuedPointsEditor({
               <button
                 type="submit"
                 disabled={settingsSaving}
-                className="px-3 py-1.5 bg-blue-600 text-white text-xs rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+                className="px-3 py-1.5 bg-gradient-to-r from-indigo-600 to-violet-600 text-white text-xs rounded-lg hover:from-indigo-500 hover:to-violet-500 disabled:opacity-50 transition shadow"
               >
                 {settingsSaving ? "保存中..." : "保存"}
               </button>
               <button
                 type="button"
                 onClick={() => setSettingsOpen(false)}
-                className="px-3 py-1.5 text-xs text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition"
+                className="px-3 py-1.5 text-xs text-slate-500 border border-slate-200 rounded-lg hover:bg-slate-50 transition"
               >
                 キャンセル
               </button>
@@ -542,7 +566,7 @@ function IssuedPointsEditor({
       )}
 
       {/* 現在の状態 */}
-      <div className="flex flex-col sm:flex-row gap-6 items-center">
+      <div className="flex flex-col sm:flex-row gap-6 items-center bg-gradient-to-br from-slate-50 to-indigo-50 rounded-xl p-4 border border-indigo-50">
         {/* 円グラフ */}
         <div className="w-48 h-48 shrink-0">
           <ResponsiveContainer width="100%" height="100%">
@@ -570,28 +594,28 @@ function IssuedPointsEditor({
         </div>
 
         {/* 数値サマリー */}
-        <div className="flex flex-wrap gap-6 text-sm">
-          <div>
-            <p className="text-gray-400 text-xs mb-0.5">発行済み</p>
-            <p className="text-2xl font-bold text-gray-800">{formatPoint(totalIssuedPoints, group)}</p>
+        <div className="flex flex-wrap gap-4 text-sm">
+          <div className="bg-white rounded-xl px-4 py-3 border border-slate-100 shadow-sm min-w-[100px]">
+            <p className="text-slate-400 text-xs mb-1">発行済み</p>
+            <p className="text-xl font-bold text-slate-700">{formatPoint(totalIssuedPoints, group)}</p>
           </div>
-          <div>
-            <p className="text-gray-400 text-xs mb-0.5">流通中</p>
-            <p className="text-2xl font-bold text-blue-600">{formatPoint(totalCirculating, group)}</p>
+          <div className="bg-white rounded-xl px-4 py-3 border border-indigo-100 shadow-sm min-w-[100px]">
+            <p className="text-indigo-400 text-xs mb-1">流通中</p>
+            <p className="text-xl font-bold text-indigo-600">{formatPoint(totalCirculating, group)}</p>
           </div>
-          <div>
-            <p className="text-gray-400 text-xs mb-0.5">未流通（回収可能）</p>
-            <p className="text-2xl font-bold text-green-600">{formatPoint(Math.max(reclaimable, 0), group)}</p>
+          <div className="bg-white rounded-xl px-4 py-3 border border-emerald-100 shadow-sm min-w-[100px]">
+            <p className="text-emerald-400 text-xs mb-1">未流通（回収可能）</p>
+            <p className="text-xl font-bold text-emerald-600">{formatPoint(Math.max(reclaimable, 0), group)}</p>
           </div>
         </div>
       </div>
 
       {isAdmin && (
-        <div className="grid grid-cols-2 gap-4 pt-2 border-t border-gray-100">
+        <div className="grid grid-cols-2 gap-4 pt-4 border-t border-slate-100">
           <DeltaForm
             label="追加発行"
             buttonLabel="発行する"
-            buttonClass="bg-blue-600 hover:bg-blue-700"
+            buttonClass="bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 shadow-indigo-200"
             sign={1}
             onSubmit={sendDelta}
             group={group}
@@ -599,7 +623,7 @@ function IssuedPointsEditor({
           <DeltaForm
             label={`回収（最大 ${formatPoint(Math.max(reclaimable, 0), group)}）`}
             buttonLabel="回収する"
-            buttonClass="bg-red-500 hover:bg-red-600"
+            buttonClass="bg-gradient-to-r from-red-500 to-rose-600 hover:from-red-400 hover:to-rose-500 shadow-red-200"
             maxPt={reclaimable}
             sign={-1}
             onSubmit={sendDelta}
@@ -684,8 +708,11 @@ function GrantPointsSection({
   }
 
   return (
-    <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-4">
-      <h3 className="font-semibold text-gray-800">ポイント付与</h3>
+    <section className="bg-white border border-slate-100 rounded-2xl p-6 space-y-4 shadow-sm">
+      <h3 className="font-bold text-slate-700 flex items-center gap-2">
+        <span className="w-1.5 h-5 bg-gradient-to-b from-emerald-400 to-teal-500 rounded-full inline-block" />
+        ポイント付与
+      </h3>
 
       <div className="flex gap-4">
         <label className="flex items-center gap-2 cursor-pointer text-sm">
@@ -769,7 +796,7 @@ function GrantPointsSection({
         <button
           type="submit"
           disabled={submitting}
-          className="px-5 py-2 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700 disabled:opacity-50 transition"
+          className="px-5 py-2 bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-400 hover:to-teal-500 text-white text-sm rounded-lg disabled:opacity-50 transition shadow shadow-emerald-200"
         >
           {submitting ? "付与中..." : "付与する"}
         </button>
@@ -816,7 +843,7 @@ function DeltaForm({
 
   return (
     <div>
-      <p className="text-sm font-medium text-gray-700 mb-2">{label}</p>
+      <p className="text-sm font-semibold text-slate-600 mb-2">{label}</p>
       <form onSubmit={handleSubmit} className="flex gap-2 items-center">
         <input
           type="number"
@@ -826,14 +853,14 @@ function DeltaForm({
           value={amount || ""}
           onChange={(e) => setAmount(Number(e.target.value))}
           placeholder={unitLabel}
-          className="w-28 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="w-28 border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
           required
         />
-        <span className="text-sm text-gray-500">{unitLabel}</span>
+        <span className="text-sm text-slate-400">{unitLabel}</span>
         <button
           type="submit"
           disabled={saving || (maxPt !== undefined && maxPt <= 0)}
-          className={`px-4 py-2 text-white text-sm rounded-lg disabled:opacity-50 transition ${buttonClass}`}
+          className={`px-4 py-2 text-white text-sm rounded-lg disabled:opacity-50 transition shadow ${buttonClass}`}
         >
           {saving ? "..." : buttonLabel}
         </button>
@@ -859,8 +886,11 @@ function GroupSettingsSection({
   onProposalRewardUpdated: (v: number) => void;
 }) {
   return (
-    <section className="bg-white border border-gray-200 rounded-xl p-6 space-y-5">
-      <h3 className="font-semibold text-gray-800">グループ設定</h3>
+    <section className="bg-white border border-slate-100 rounded-2xl p-6 space-y-5 shadow-sm">
+      <h3 className="font-bold text-slate-700 flex items-center gap-2">
+        <span className="w-1.5 h-5 bg-gradient-to-b from-amber-400 to-orange-500 rounded-full inline-block" />
+        グループ設定
+      </h3>
 
       {/* 提案報酬 */}
       <SettingRow
@@ -910,7 +940,7 @@ function SettingRow({
           {canEdit && !editing && (
             <button
               onClick={() => setEditing(true)}
-              className="text-xs text-gray-400 hover:text-gray-600 transition border border-gray-200 rounded px-2 py-0.5"
+              className="text-xs text-indigo-500 hover:text-indigo-700 transition border border-indigo-200 rounded-lg px-2.5 py-0.5 hover:bg-indigo-50"
             >
               変更
             </button>
@@ -956,24 +986,24 @@ function ProposalRewardForm({
   }
 
   return (
-    <form onSubmit={handleSave} className="flex items-center gap-3 bg-gray-50 rounded-lg px-3 py-2">
+    <form onSubmit={handleSave} className="flex items-center gap-3 bg-slate-50 rounded-xl px-3 py-2.5 border border-slate-100">
       <input
         type="number"
         min={0}
         value={value}
         onChange={(e) => setValue(Number(e.target.value))}
-        className="w-24 border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className="w-24 border border-slate-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
         required
       />
-      <span className="text-sm text-gray-500">pt</span>
+      <span className="text-sm text-slate-400">pt</span>
       <button
         type="submit"
         disabled={saving}
-        className="px-3 py-1.5 bg-blue-600 text-white text-xs rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+        className="px-3 py-1.5 bg-gradient-to-r from-indigo-600 to-violet-600 text-white text-xs rounded-lg hover:from-indigo-500 hover:to-violet-500 disabled:opacity-50 transition"
       >
         {saving ? "保存中..." : "保存"}
       </button>
-      <button type="button" onClick={onCancel} className="text-xs text-gray-400 hover:text-gray-600 transition">
+      <button type="button" onClick={onCancel} className="text-xs text-slate-400 hover:text-slate-600 transition">
         キャンセル
       </button>
       {error && <p className="text-xs text-red-600">{error}</p>}

--- a/app/(app)/groups/page.tsx
+++ b/app/(app)/groups/page.tsx
@@ -51,53 +51,78 @@ export default function GroupsPage() {
     }
   }
 
+  const GRADIENT_COLORS = [
+    "from-indigo-500 to-violet-600",
+    "from-violet-500 to-purple-600",
+    "from-blue-500 to-indigo-600",
+    "from-purple-500 to-pink-600",
+    "from-cyan-500 to-blue-600",
+  ];
+
   return (
-    <div className="max-w-3xl mx-auto px-6 py-10 space-y-8">
+    <div className="max-w-3xl mx-auto px-6 py-10 space-y-10">
+      {/* 作成フォーム */}
       <section>
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">グループを作成</h2>
+        <h2 className="text-xl font-bold text-slate-800 mb-4 flex items-center gap-2">
+          <span className="w-1 h-6 bg-gradient-to-b from-indigo-500 to-violet-600 rounded-full inline-block" />
+          グループを作成
+        </h2>
         <form onSubmit={handleCreate} className="flex gap-3">
           <input
             type="text"
             value={newGroupName}
             onChange={(e) => setNewGroupName(e.target.value)}
-            placeholder="グループ名"
-            className="flex-1 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            placeholder="グループ名を入力..."
+            className="flex-1 border border-slate-200 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-white shadow-sm"
             required
           />
           <button
             type="submit"
             disabled={creating}
-            className="px-5 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+            className="px-6 py-2.5 bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-sm font-semibold rounded-xl disabled:opacity-50 transition shadow-lg shadow-indigo-200"
           >
             {creating ? "作成中..." : "作成"}
           </button>
         </form>
-        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+        {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
       </section>
 
+      {/* グループ一覧 */}
       <section>
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">グループ一覧</h2>
+        <h2 className="text-xl font-bold text-slate-800 mb-4 flex items-center gap-2">
+          <span className="w-1 h-6 bg-gradient-to-b from-indigo-500 to-violet-600 rounded-full inline-block" />
+          グループ一覧
+        </h2>
         {groups.length === 0 ? (
-          <p className="text-gray-500 text-sm">グループがありません。</p>
+          <div className="text-center py-16 text-slate-400">
+            <p className="text-4xl mb-3">⬡</p>
+            <p className="text-sm">グループがまだありません。最初のグループを作成しましょう。</p>
+          </div>
         ) : (
           <ul className="space-y-3">
-            {groups.map((g) => (
+            {groups.map((g, i) => (
               <li key={g.id}>
                 <Link
                   href={`/groups/${g.id}`}
-                  className="block bg-white border border-gray-200 rounded-xl px-6 py-4 hover:shadow-md transition"
+                  className="flex items-center gap-4 bg-white border border-slate-100 rounded-2xl px-6 py-5 hover:shadow-lg hover:-translate-y-0.5 transition-all shadow-sm"
                 >
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium text-gray-800">{g.name}</span>
-                    <span className="text-xs text-gray-400">
-                      メンバー {g.members.length}人
-                    </span>
+                  <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${GRADIENT_COLORS[i % GRADIENT_COLORS.length]} flex items-center justify-center text-white font-bold text-xl shadow`}>
+                    {g.name[0]}
                   </div>
-                  {g.totalIssuedPoints !== undefined && (
-                    <p className="text-xs text-gray-500 mt-1">
-                      管理側発行済みポイント: {g.totalIssuedPoints} pt
-                    </p>
-                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-bold text-slate-800 text-base">{g.name}</p>
+                    {g.totalIssuedPoints !== undefined && (
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        発行済み: <span className="font-semibold text-indigo-500">{g.totalIssuedPoints.toLocaleString("ja-JP")} pt</span>
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <span className="text-xs text-slate-400 bg-slate-50 px-2.5 py-1 rounded-full border border-slate-100">
+                      {g.members.length} 人
+                    </span>
+                    <span className="text-slate-300">→</span>
+                  </div>
                 </Link>
               </li>
             ))}

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -8,12 +8,20 @@ export default async function HomePage() {
 
   return (
     <div className="max-w-2xl mx-auto px-6 py-10 space-y-8">
-      <div>
-        <h2 className="text-2xl font-semibold text-gray-800 mb-1">
-          ようこそ、{session.user?.name ?? session.user?.email} さん
-        </h2>
-        <p className="text-gray-500 text-sm">左のサイドバーからグループを選択してください。</p>
+      {/* ウェルカムバナー */}
+      <div className="relative bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 rounded-2xl p-8 shadow-xl overflow-hidden">
+        <div className="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/4 pointer-events-none" />
+        <div className="absolute bottom-0 left-0 w-48 h-48 bg-white/5 rounded-full translate-y-1/2 -translate-x-1/4 pointer-events-none" />
+        <div className="relative">
+          <p className="text-indigo-200 text-sm font-medium mb-1">ようこそ</p>
+          <h2 className="text-3xl font-bold text-white">
+            {session.user?.name ?? session.user?.email}
+            <span className="text-indigo-200"> さん</span>
+          </h2>
+          <p className="text-indigo-200 text-sm mt-2">左のサイドバーからグループを選択してください。</p>
+        </div>
       </div>
+
       <InvitationList />
     </div>
   );

--- a/app/InvitationList.tsx
+++ b/app/InvitationList.tsx
@@ -41,37 +41,44 @@ export default function InvitationList() {
 
   return (
     <section>
-      <h3 className="font-semibold text-gray-700 mb-3">
-        招待が届いています
-        <span className="ml-2 text-blue-600 font-bold">{invitations.length}</span>
-      </h3>
+      <div className="flex items-center gap-3 mb-4">
+        <h3 className="font-bold text-slate-700 text-lg">招待が届いています</h3>
+        <span className="px-2.5 py-0.5 bg-gradient-to-r from-indigo-600 to-violet-600 text-white text-sm font-bold rounded-full shadow">
+          {invitations.length}
+        </span>
+      </div>
       <ul className="space-y-3">
         {invitations.map((inv) => (
           <li
             key={inv.id}
-            className="bg-white border border-blue-200 rounded-xl px-6 py-4 flex items-center justify-between gap-4"
+            className="bg-white border border-indigo-100 rounded-xl px-6 py-4 flex items-center justify-between gap-4 shadow-sm hover:shadow-md transition"
           >
-            <div>
-              <p className="text-sm font-medium text-gray-800">
-                <span className="text-blue-600">{inv.group.name}</span> から招待が届いています
-              </p>
-              <p className="text-xs text-gray-400 mt-0.5">
-                招待者: {inv.inviter.user.name ?? inv.inviter.user.email} ／
-                ロール: {inv.role === "LEADER" ? "管理側メンバー（LEADER）" : "一般メンバー"}
-              </p>
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 flex items-center justify-center text-white font-bold text-lg shadow">
+                {inv.group.name[0]}
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-slate-800">
+                  <span className="text-indigo-600">{inv.group.name}</span> から招待が届いています
+                </p>
+                <p className="text-xs text-slate-400 mt-0.5">
+                  招待者: {inv.inviter.user.name ?? inv.inviter.user.email} ／
+                  ロール: {inv.role === "LEADER" ? "管理側メンバー（LEADER）" : "一般メンバー"}
+                </p>
+              </div>
             </div>
             <div className="flex gap-2 shrink-0">
               <button
                 onClick={() => respond(inv.id, "accept")}
                 disabled={processing === inv.id}
-                className="px-4 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
+                className="px-4 py-1.5 bg-gradient-to-r from-indigo-600 to-violet-600 text-white text-sm rounded-lg hover:from-indigo-500 hover:to-violet-500 disabled:opacity-50 transition shadow shadow-indigo-200"
               >
                 承認
               </button>
               <button
                 onClick={() => respond(inv.id, "decline")}
                 disabled={processing === inv.id}
-                className="px-4 py-1.5 bg-gray-100 text-gray-600 text-sm rounded-lg hover:bg-gray-200 disabled:opacity-50 transition"
+                className="px-4 py-1.5 bg-slate-100 text-slate-600 text-sm rounded-lg hover:bg-slate-200 disabled:opacity-50 transition"
               >
                 拒否
               </button>

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -9,14 +9,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
+    <div className="min-h-screen flex flex-col bg-slate-50">
       {/* ヘッダー */}
-      <header className="bg-white border-b border-gray-200 z-10 shrink-0">
+      <header className="bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 z-10 shrink-0 shadow-lg">
         <div className="px-4 py-3 flex items-center gap-4">
           {/* サイドバートグル */}
           <button
             onClick={() => setSidebarOpen((prev) => !prev)}
-            className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 transition"
+            className="p-1.5 rounded-lg text-white/70 hover:text-white hover:bg-white/10 transition"
             aria-label="サイドバーを切り替え"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -24,38 +24,32 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </svg>
           </button>
 
-          <Link href="/" className="text-lg font-bold text-gray-800 mr-auto">
+          <Link href="/" className="text-lg font-bold text-white mr-auto tracking-wide flex items-center gap-2">
+            <span className="text-2xl">⬡</span>
             Group Point
           </Link>
 
-          <Link
-            href="/quests"
-            className="text-sm text-gray-600 hover:text-blue-600 transition"
-          >
-            案件一覧
-          </Link>
-          <Link
-            href="/subquests"
-            className="text-sm text-gray-600 hover:text-blue-600 transition"
-          >
-            サブクエスト一覧
-          </Link>
-          <Link
-            href="/profile"
-            className="text-sm text-gray-600 hover:text-blue-600 transition"
-          >
-            プロフィール
-          </Link>
-          <Link
-            href="/contact"
-            className="text-sm text-gray-600 hover:text-blue-600 transition"
-          >
-            お問い合わせ
-          </Link>
+          <nav className="flex items-center gap-1">
+            {[
+              { href: "/quests", label: "案件一覧" },
+              { href: "/subquests", label: "サブクエスト" },
+              { href: "/profile", label: "プロフィール" },
+              { href: "/contact", label: "お問い合わせ" },
+            ].map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className="text-sm text-white/80 hover:text-white hover:bg-white/10 px-3 py-1.5 rounded-lg transition"
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+
           <form action={logout}>
             <button
               type="submit"
-              className="text-sm px-3 py-1.5 bg-gray-100 hover:bg-gray-200 rounded-lg transition"
+              className="text-sm px-4 py-1.5 bg-white/10 hover:bg-white/20 text-white rounded-lg border border-white/20 transition"
             >
               ログアウト
             </button>

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -23,20 +23,20 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <aside className="w-56 shrink-0 bg-white border-r border-gray-200 flex flex-col">
-      <div className="px-4 py-4 border-b border-gray-100">
+    <aside className="w-60 shrink-0 bg-slate-900 flex flex-col shadow-xl">
+      <div className="px-4 py-4 border-b border-slate-700">
         <Link
           href="/groups"
-          className="text-xs font-semibold text-gray-400 uppercase tracking-wide hover:text-gray-600 transition"
+          className="text-xs font-bold text-slate-400 uppercase tracking-widest hover:text-slate-200 transition"
         >
           グループ一覧
         </Link>
       </div>
-      <nav className="flex-1 overflow-y-auto py-2">
+      <nav className="flex-1 overflow-y-auto py-3">
         {groups.length === 0 ? (
-          <p className="px-4 py-3 text-xs text-gray-400">グループなし</p>
+          <p className="px-4 py-3 text-xs text-slate-500">グループなし</p>
         ) : (
-          <ul>
+          <ul className="space-y-0.5 px-2">
             {groups.map((g) => {
               const active = pathname.startsWith(`/groups/${g.id}`);
               const myMember = myUserId
@@ -46,16 +46,16 @@ export default function Sidebar() {
                 <li key={g.id}>
                   <Link
                     href={`/groups/${g.id}`}
-                    className={`flex items-center justify-between gap-2 px-4 py-2.5 transition ${
+                    className={`flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg transition ${
                       active
-                        ? "bg-blue-50 text-blue-700"
-                        : "text-gray-700 hover:bg-gray-50"
+                        ? "bg-gradient-to-r from-indigo-600 to-violet-600 text-white shadow-lg"
+                        : "text-slate-300 hover:bg-slate-800 hover:text-white"
                     }`}
                   >
-                    <span className={`text-sm truncate ${active ? "font-medium" : ""}`}>{g.name}</span>
+                    <span className={`text-sm truncate ${active ? "font-semibold" : ""}`}>{g.name}</span>
                     {myMember !== null && myMember !== undefined && (
-                      <span className={`text-xs font-bold shrink-0 ${active ? "text-blue-500" : "text-gray-400"}`}>
-                        {myMember.memberPoints} pt
+                      <span className={`text-xs font-bold shrink-0 ${active ? "text-indigo-200" : "text-slate-500"}`}>
+                        {myMember.memberPoints.toLocaleString("ja-JP")} pt
                       </span>
                     )}
                   </Link>
@@ -65,12 +65,13 @@ export default function Sidebar() {
           </ul>
         )}
       </nav>
-      <div className="px-4 py-3 border-t border-gray-100">
+      <div className="px-3 py-4 border-t border-slate-700">
         <Link
           href="/groups"
-          className="text-xs text-blue-600 hover:text-blue-800 transition"
+          className="flex items-center justify-center gap-2 w-full py-2 rounded-lg bg-gradient-to-r from-indigo-600 to-violet-600 text-white text-sm font-medium hover:from-indigo-500 hover:to-violet-500 transition shadow"
         >
-          + グループを作成
+          <span className="text-lg leading-none">+</span>
+          グループを作成
         </Link>
       </div>
     </aside>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -33,67 +33,77 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-md p-8">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
-          ログイン
-        </h1>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900">
+      {/* 背景の装飾 */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-indigo-600/20 rounded-full blur-3xl" />
+        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-violet-600/20 rounded-full blur-3xl" />
+      </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-700 mb-1"
+      <div className="relative w-full max-w-md">
+        {/* ロゴ */}
+        <div className="text-center mb-8">
+          <span className="text-5xl">⬡</span>
+          <h1 className="mt-3 text-3xl font-bold text-white tracking-wide">Group Point</h1>
+          <p className="text-slate-400 text-sm mt-1">グループポイント管理システム</p>
+        </div>
+
+        <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl p-8">
+          <h2 className="text-xl font-bold text-white mb-6">ログイン</h2>
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-slate-300 mb-1.5">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                placeholder="example@email.com"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-slate-300 mb-1.5">
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {error && (
+              <div className="px-4 py-2.5 bg-red-500/10 border border-red-500/20 rounded-lg">
+                <p className="text-sm text-red-400">{error}</p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-2.5 px-4 bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white font-semibold rounded-lg disabled:opacity-50 transition shadow-lg shadow-indigo-500/25"
             >
-              メールアドレス
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="example@email.com"
-            />
-          </div>
+              {loading ? "ログイン中..." : "ログイン"}
+            </button>
+          </form>
 
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              パスワード
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="••••••••"
-            />
-          </div>
-
-          {error && (
-            <p className="text-sm text-red-500">{error}</p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
-          >
-            {loading ? "ログイン中..." : "ログイン"}
-          </button>
-        </form>
-        <p className="mt-6 text-center text-sm text-gray-500">
-          アカウントをお持ちでない方は{" "}
-          <Link href="/signup" className="text-blue-600 hover:underline">
-            新規登録
-          </Link>
-        </p>
+          <p className="mt-6 text-center text-sm text-slate-400">
+            アカウントをお持ちでない方は{" "}
+            <Link href="/signup" className="text-indigo-400 hover:text-indigo-300 font-medium transition">
+              新規登録
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -34,84 +34,92 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-md p-8">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
-          アカウント作成
-        </h1>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900">
+      {/* 背景の装飾 */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-violet-600/20 rounded-full blur-3xl" />
+        <div className="absolute bottom-1/4 left-1/4 w-96 h-96 bg-indigo-600/20 rounded-full blur-3xl" />
+      </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div>
-            <label
-              htmlFor="name"
-              className="block text-sm font-medium text-gray-700 mb-1"
+      <div className="relative w-full max-w-md">
+        {/* ロゴ */}
+        <div className="text-center mb-8">
+          <span className="text-5xl">⬡</span>
+          <h1 className="mt-3 text-3xl font-bold text-white tracking-wide">Group Point</h1>
+          <p className="text-slate-400 text-sm mt-1">グループポイント管理システム</p>
+        </div>
+
+        <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl p-8">
+          <h2 className="text-xl font-bold text-white mb-6">アカウント作成</h2>
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-slate-300 mb-1.5">
+                名前（任意）
+              </label>
+              <input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                placeholder="山田 太郎"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-slate-300 mb-1.5">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                placeholder="example@email.com"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-slate-300 mb-1.5">
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+                className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {error && (
+              <div className="px-4 py-2.5 bg-red-500/10 border border-red-500/20 rounded-lg">
+                <p className="text-sm text-red-400">{error}</p>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-2.5 px-4 bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white font-semibold rounded-lg disabled:opacity-50 transition shadow-lg shadow-indigo-500/25"
             >
-              名前（任意）
-            </label>
-            <input
-              id="name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="山田 太郎"
-            />
-          </div>
+              {loading ? "作成中..." : "アカウントを作成"}
+            </button>
+          </form>
 
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              メールアドレス
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="example@email.com"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              パスワード
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={8}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="••••••••"
-            />
-          </div>
-
-          {error && <p className="text-sm text-red-500">{error}</p>}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-2 px-4 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:opacity-50 transition"
-          >
-            {loading ? "作成中..." : "アカウントを作成"}
-          </button>
-        </form>
-
-        <p className="mt-6 text-center text-sm text-gray-500">
-          すでにアカウントをお持ちの方は{" "}
-          <Link href="/login" className="text-blue-600 hover:underline">
-            ログイン
-          </Link>
-        </p>
+          <p className="mt-6 text-center text-sm text-slate-400">
+            すでにアカウントをお持ちの方は{" "}
+            <Link href="/login" className="text-indigo-400 hover:text-indigo-300 font-medium transition">
+              ログイン
+            </Link>
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

全体のUIをグラデーション・ダークサイドバーを使ったモダンなデザインに刷新しました。

## 変更内容

- **ヘッダー**: インディゴ〜バイオレットのグラデーション
- **サイドバー**: ダーク背景（slate-900）、アクティブ項目にグラデーション
- **ログイン/登録**: ダーク背景 + グラスモーフィズム風カード
- **ホーム**: グラデーションウェルカムバナー
- **グループ一覧**: グラデーションアイコン付きカード、ホバーアニメーション
- **グループ詳細**: グラデーションヘッダー、カラーアイコン付きナビカード
- **ポイント統計**: 色分けされた統計カード
- **ボタン全般**: グラデーション（インディゴ/バイオレット/エメラルド）
- **お問い合わせ**: グラデーションヘッダー + モダンフォーム